### PR TITLE
Only compile HLSL shaders for RenderDemo on windows

### DIFF
--- a/src/RenderDemo/RenderDemo.csproj
+++ b/src/RenderDemo/RenderDemo.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>exe</OutputType>
-    <PreprocessHlslShaders>true</PreprocessHlslShaders>
+    <PreprocessHlslShaders>$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))</PreprocessHlslShaders>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ImGui.NET" Version="0.2.1" />


### PR DESCRIPTION
Fixes #6 by only compiling HLSL Shaders for the RenderDemo if the project is being built on windows. I've tested this on arch linux and on a Windows 10 VM. Shaders are not built on arch and the project can be built and run successfully. On windows, it attempts to compile shaders, but I think I'm missing some tools so the build fails with the same errors I was getting in #6.