### PR TITLE
Fix copying non-square OpenGL textures

### DIFF
--- a/src/Veldrid/CommandList.cs
+++ b/src/Veldrid/CommandList.cs
@@ -662,7 +662,7 @@ namespace Veldrid
                 CopyTexture(
                     source, 0, 0, 0, level, 0,
                     destination, 0, 0, 0, level, 0,
-                    source.Width, source.Width, source.Depth,
+                    source.Width, source.Height, source.Depth,
                     source.ArrayLayers);
             }
         }


### PR DESCRIPTION
Discovered when my application was getting an Access Violation in a
memmove function when trying to copy a 512x128 texture from staging to
an ordinary sampled texture.

Didn't crash on Windows at all, but crashed consistently on Mac OS X.

.NET Core (& VS Mac aka MonoDevelop) was uniquely unhelpful in debugging. 
(Kept crashing in breakpoints before the actual copy, even on the right thread. I eventually found this line of code was the culprit after much Console.WriteLine()ing and delaying threads with sleep commands. Sigh...)

Veldrid is cool though. I'm enjoying using it so far. 👍 