### PR TITLE
Implement R8_G8_SNorm and R32_G32_B32_A32_UInt pixel formats

### DIFF
--- a/src/Veldrid.Tests/TextureTests.cs
+++ b/src/Veldrid.Tests/TextureTests.cs
@@ -67,14 +67,14 @@ namespace Veldrid.Tests
             }
 
             MappedResource map = GD.Map(texture, MapMode.Read, 0);
-            ushort* mappedFloatPtr = (ushort*)map.Data;
+            ushort* mappedUShortPtr = (ushort*)map.Data;
 
             for (int y = 0; y < 1024; y++)
             {
                 for (int x = 0; x < 1024; x++)
                 {
                     ushort index = (ushort)(y * 1024 + x);
-                    Assert.Equal(index, mappedFloatPtr[index]);
+                    Assert.Equal(index, mappedUShortPtr[index]);
                 }
             }
         }
@@ -93,7 +93,7 @@ namespace Veldrid.Tests
             }
 
             MappedResource map = GD.Map(texture, MapMode.Read, 0);
-            byte* mappedFloatPtr = (byte*)map.Data;
+            byte* mappedBytePtr = (byte*)map.Data;
 
             for (int y = 0; y < 8; y++)
             {
@@ -101,11 +101,11 @@ namespace Veldrid.Tests
                 {
                     uint index0 = (uint)(y * map.RowPitch + x * 2);
                     byte value0 = (byte)(y * 8 * 2 + x * 2);
-                    Assert.Equal(value0, mappedFloatPtr[index0]);
+                    Assert.Equal(value0, mappedBytePtr[index0]);
 
                     uint index1 = (uint)(index0 + 1);
                     byte value1 = (byte)(value0 + 1);
-                    Assert.Equal(value1, mappedFloatPtr[index1]);
+                    Assert.Equal(value1, mappedBytePtr[index1]);
                 }
             }
         }
@@ -124,7 +124,7 @@ namespace Veldrid.Tests
             }
 
             MappedResource map = GD.Map(texture, MapMode.Read, 2);
-            ushort* mappedFloatPtr = (ushort*)map.Data;
+            ushort* mappedUShortPtr = (ushort*)map.Data;
 
             for (int y = 0; y < 256; y++)
             {
@@ -132,7 +132,7 @@ namespace Veldrid.Tests
                 {
                     uint mapIndex = (uint)(y * (map.RowPitch / sizeof(ushort)) + x);
                     ushort value = (ushort)(y * 256 + x);
-                    Assert.Equal(value, mappedFloatPtr[mapIndex]);
+                    Assert.Equal(value, mappedUShortPtr[mapIndex]);
                 }
             }
         }

--- a/src/Veldrid.Tests/TextureTests.cs
+++ b/src/Veldrid.Tests/TextureTests.cs
@@ -18,6 +18,16 @@ namespace Veldrid.Tests
         }
 
         [Fact]
+        public void Map_Succeeds_R32_G32_B32_A32_UInt()
+        {
+            Texture texture = RF.CreateTexture(
+                TextureDescription.Texture2D(1024, 1024, 1, 1, PixelFormat.R32_G32_B32_A32_UInt, TextureUsage.Staging));
+
+            MappedResource map = GD.Map(texture, MapMode.ReadWrite, 0);
+            GD.Unmap(texture, 0);
+        }
+
+        [Fact]
         public unsafe void Update_ThenMapRead_Succeeds_R32Float()
         {
             Texture texture = RF.CreateTexture(
@@ -65,6 +75,37 @@ namespace Veldrid.Tests
                 {
                     ushort index = (ushort)(y * 1024 + x);
                     Assert.Equal(index, mappedFloatPtr[index]);
+                }
+            }
+        }
+
+        [Fact]
+        public unsafe void Update_ThenMapRead_Succeeds_R8_G8_SNorm()
+        {
+            Texture texture = RF.CreateTexture(
+                TextureDescription.Texture2D(8, 8, 1, 1, PixelFormat.R8_G8_SNorm, TextureUsage.Staging));
+
+            byte[] data = Enumerable.Range(0, 8 * 8 * 2).Select(i => (byte)i).ToArray();
+
+            fixed (byte* dataPtr = data)
+            {
+                GD.UpdateTexture(texture, (IntPtr)dataPtr, 8 * 8 * sizeof(byte) * 2, 0, 0, 0, 8, 8, 1, 0, 0);
+            }
+
+            MappedResource map = GD.Map(texture, MapMode.Read, 0);
+            byte* mappedFloatPtr = (byte*)map.Data;
+
+            for (int y = 0; y < 8; y++)
+            {
+                for (int x = 0; x < 8; x++)
+                {
+                    uint index0 = (uint)(y * map.RowPitch + x * 2);
+                    byte value0 = (byte)(y * 8 * 2 + x * 2);
+                    Assert.Equal(value0, mappedFloatPtr[index0]);
+
+                    uint index1 = (uint)(index0 + 1);
+                    byte value1 = (byte)(value0 + 1);
+                    Assert.Equal(value1, mappedFloatPtr[index1]);
                 }
             }
         }

--- a/src/Veldrid/D3D11/D3D11Formats.cs
+++ b/src/Veldrid/D3D11/D3D11Formats.cs
@@ -18,10 +18,14 @@ namespace Veldrid.D3D11
                     return Format.B8G8R8A8_UNorm;
                 case PixelFormat.R8_UNorm:
                     return Format.R8_UNorm;
+                case PixelFormat.R8_G8_SNorm:
+                    return Format.R8G8_SNorm;
                 case PixelFormat.R16_UNorm:
                     return depthFormat ? Format.R16_Typeless : Format.R16_UNorm;
                 case PixelFormat.R32_G32_B32_A32_Float:
                     return Format.R32G32B32A32_Float;
+                case PixelFormat.R32_G32_B32_A32_UInt:
+                    return Format.R32G32B32A32_UInt;
                 case PixelFormat.R32_Float:
                     return depthFormat ? Format.R32_Typeless : Format.R32_Float;
                 case PixelFormat.BC3_UNorm:
@@ -163,11 +167,15 @@ namespace Veldrid.D3D11
                     return PixelFormat.B8_G8_R8_A8_UNorm;
                 case Format.R8_UNorm:
                     return PixelFormat.R8_UNorm;
+                case Format.R8G8_SNorm:
+                    return PixelFormat.R8_G8_SNorm;
                 case Format.R16_UNorm:
                 case Format.D16_UNorm:
                     return PixelFormat.R16_UNorm;
                 case Format.R32G32B32A32_Float:
                     return PixelFormat.R32_G32_B32_A32_Float;
+                case Format.R32G32B32A32_UInt:
+                    return PixelFormat.R32_G32_B32_A32_UInt;
                 case Format.R32_Float:
                     return PixelFormat.R32_Float;
                 case Format.D24_UNorm_S8_UInt:

--- a/src/Veldrid/FormatHelpers.cs
+++ b/src/Veldrid/FormatHelpers.cs
@@ -10,6 +10,7 @@ namespace Veldrid
             {
                 case PixelFormat.R8_UNorm:
                     return 1;
+                case PixelFormat.R8_G8_SNorm:
                 case PixelFormat.R16_UNorm:
                     return 2;
                 case PixelFormat.R8_G8_B8_A8_UNorm:
@@ -17,6 +18,7 @@ namespace Veldrid
                 case PixelFormat.R32_Float:
                     return 4;
                 case PixelFormat.R32_G32_B32_A32_Float:
+                case PixelFormat.R32_G32_B32_A32_UInt:
                     return 16;
                 case PixelFormat.BC3_UNorm:
                     return 1; // Not really

--- a/src/Veldrid/MTL/MTLFormats.cs
+++ b/src/Veldrid/MTL/MTLFormats.cs
@@ -23,10 +23,14 @@ namespace Veldrid.MTL
                     return depthFormat ? MTLPixelFormat.Depth32Float : MTLPixelFormat.R32Float;
                 case PixelFormat.R32_G32_B32_A32_Float:
                     return MTLPixelFormat.RGBA32Float;
+                case PixelFormat.R32_G32_B32_A32_UInt:
+                    return MTLPixelFormat.RGBA32Uint;
                 case PixelFormat.R8_G8_B8_A8_UNorm:
                     return MTLPixelFormat.RGBA8Unorm;
                 case PixelFormat.R8_UNorm:
                     return MTLPixelFormat.R8Unorm;
+                case PixelFormat.R8_G8_SNorm:
+                    return MTLPixelFormat.RG8Snorm;
                 default:
                     throw Illegal.Value<PixelFormat>();
             }

--- a/src/Veldrid/OpenGL/OpenGLFormats.cs
+++ b/src/Veldrid/OpenGL/OpenGLFormats.cs
@@ -50,10 +50,14 @@ namespace Veldrid.OpenGL
                     return PixelInternalFormat.Rgba;
                 case PixelFormat.R8_UNorm:
                     return PixelInternalFormat.R8ui;
+                case PixelFormat.R8_G8_SNorm:
+                    return PixelInternalFormat.Rg8Snorm;
                 case PixelFormat.R16_UNorm:
                     return PixelInternalFormat.R16ui;
                 case PixelFormat.R32_G32_B32_A32_Float:
                     return PixelInternalFormat.Rgba32f;
+                case PixelFormat.R32_G32_B32_A32_UInt:
+                    return PixelInternalFormat.Rgba32ui;
                 case PixelFormat.R32_Float:
                     return PixelInternalFormat.R32f;
                 case PixelFormat.BC3_UNorm:
@@ -94,10 +98,14 @@ namespace Veldrid.OpenGL
                     return GLPixelFormat.Bgra;
                 case PixelFormat.R8_UNorm:
                     return GLPixelFormat.Red;
+                case PixelFormat.R8_G8_SNorm:
+                    return GLPixelFormat.RgInteger;
                 case PixelFormat.R16_UNorm:
                     return GLPixelFormat.Red;
                 case PixelFormat.R32_G32_B32_A32_Float:
                     return GLPixelFormat.Rgba;
+                case PixelFormat.R32_G32_B32_A32_UInt:
+                    return GLPixelFormat.RgbaInteger;
                 case PixelFormat.R32_Float:
                     return GLPixelFormat.Red;
                 case PixelFormat.BC3_UNorm:
@@ -119,10 +127,14 @@ namespace Veldrid.OpenGL
                 case PixelFormat.B8_G8_R8_A8_UNorm:
                 case PixelFormat.R8_UNorm:
                     return GLPixelType.UnsignedByte;
+                case PixelFormat.R8_G8_SNorm:
+                    return GLPixelType.Byte;
                 case PixelFormat.R16_UNorm:
                     return GLPixelType.UnsignedShort;
                 case PixelFormat.R32_G32_B32_A32_Float:
                     return GLPixelType.Float;
+                case PixelFormat.R32_G32_B32_A32_UInt:
+                    return GLPixelType.UnsignedInt;
                 case PixelFormat.R32_Float:
                     return GLPixelType.Float;
                 case PixelFormat.BC3_UNorm:
@@ -145,10 +157,14 @@ namespace Veldrid.OpenGL
                     return SizedInternalFormat.Rgba8;
                 case PixelFormat.R8_UNorm:
                     return SizedInternalFormat.R8;
+                case PixelFormat.R8_G8_SNorm:
+                    return SizedInternalFormat.Rg8i;
                 case PixelFormat.R16_UNorm:
                     return depthFormat ? (SizedInternalFormat)PixelInternalFormat.DepthComponent16 : SizedInternalFormat.R16;
                 case PixelFormat.R32_G32_B32_A32_Float:
                     return SizedInternalFormat.Rgba32f;
+                case PixelFormat.R32_G32_B32_A32_UInt:
+                    return SizedInternalFormat.Rgba32ui;
                 case PixelFormat.R32_Float:
                     return depthFormat ? (SizedInternalFormat)PixelInternalFormat.DepthComponent32f : SizedInternalFormat.R32f;
                 case PixelFormat.BC3_UNorm:

--- a/src/Veldrid/OpenGL/OpenGLTextureView.cs
+++ b/src/Veldrid/OpenGL/OpenGLTextureView.cs
@@ -66,10 +66,14 @@ namespace Veldrid.OpenGL
                     return SizedInternalFormat.Rgba8ui;
                 case PixelFormat.R8_UNorm:
                     return SizedInternalFormat.R8ui;
+                case PixelFormat.R8_G8_SNorm:
+                    return SizedInternalFormat.Rg8i;
                 case PixelFormat.R16_UNorm:
                     return SizedInternalFormat.R16ui;
                 case PixelFormat.R32_G32_B32_A32_Float:
                     return SizedInternalFormat.Rgba32f;
+                case PixelFormat.R32_G32_B32_A32_UInt:
+                    return SizedInternalFormat.Rgba32ui;
                 case PixelFormat.R32_Float:
                     return SizedInternalFormat.R32f;
                 default:
@@ -170,10 +174,14 @@ namespace Veldrid.OpenGL
                     return PixelInternalFormat.Rgba8ui;
                 case PixelFormat.R8_UNorm:
                     return PixelInternalFormat.R8ui;
+                case PixelFormat.R8_G8_SNorm:
+                    return PixelInternalFormat.Rg8Snorm;
                 case PixelFormat.R16_UNorm:
                     return depthFormat ? PixelInternalFormat.DepthComponent16 : PixelInternalFormat.R16ui;
                 case PixelFormat.R32_G32_B32_A32_Float:
                     return PixelInternalFormat.Rgba32f;
+                case PixelFormat.R32_G32_B32_A32_UInt:
+                    return PixelInternalFormat.Rgba32ui;
                 case PixelFormat.R32_Float:
                     return depthFormat ? PixelInternalFormat.DepthComponent32f : PixelInternalFormat.R32f;
                 case PixelFormat.D32_Float_S8_UInt:

--- a/src/Veldrid/PixelFormat.cs
+++ b/src/Veldrid/PixelFormat.cs
@@ -22,6 +22,10 @@
         /// </summary>
         R8_UNorm,
         /// <summary>
+        /// RG component order. Each component is an 8-bit signed normalized integer.
+        /// </summary>
+        R8_G8_SNorm,
+        /// <summary>
         /// Single-channel, 16-bit unsigned integer. Can be used as a depth format.
         /// </summary>
         R16_UNorm,
@@ -29,6 +33,10 @@
         /// RGBA component order. Each component is a 32-bit signed floating-point value.
         /// </summary>
         R32_G32_B32_A32_Float,
+        /// <summary>
+        /// RGBA component order. Each component is a 32-bit unsigned integer.
+        /// </summary>
+        R32_G32_B32_A32_UInt,
         /// <summary>
         /// Single-channel, 32-bit signed floating-point value. Can be used as a depth format.
         /// </summary>

--- a/src/Veldrid/Vk/VkFormats.cs
+++ b/src/Veldrid/Vk/VkFormats.cs
@@ -413,10 +413,14 @@ namespace Veldrid.Vk
                     return VkFormat.B8g8r8a8Unorm;
                 case PixelFormat.R8_UNorm:
                     return VkFormat.R8Unorm;
+                case PixelFormat.R8_G8_SNorm:
+                    return VkFormat.R8g8Snorm;
                 case PixelFormat.R16_UNorm:
                     return toDepthFormat ? VkFormat.D16Unorm : VkFormat.R16Unorm;
                 case PixelFormat.R32_G32_B32_A32_Float:
                     return VkFormat.R32g32b32a32Sfloat;
+                case PixelFormat.R32_G32_B32_A32_UInt:
+                    return VkFormat.R32g32b32a32Uint;
                 case PixelFormat.R32_Float:
                     return toDepthFormat ? VkFormat.D32Sfloat : VkFormat.R32Sfloat;
                 case PixelFormat.BC3_UNorm:
@@ -437,6 +441,8 @@ namespace Veldrid.Vk
             {
                 case VkFormat.R8Unorm:
                     return PixelFormat.R8_UNorm;
+                case VkFormat.R8g8Snorm:
+                    return PixelFormat.R8_G8_SNorm;
                 case VkFormat.R8g8b8a8Unorm:
                     return PixelFormat.R8_G8_B8_A8_UNorm;
                 case VkFormat.B8g8r8a8Unorm:
@@ -445,6 +451,8 @@ namespace Veldrid.Vk
                     return PixelFormat.R16_UNorm;
                 case VkFormat.R32g32b32a32Sfloat:
                     return PixelFormat.R32_G32_B32_A32_Float;
+                case VkFormat.R32g32b32a32Uint:
+                    return PixelFormat.R32_G32_B32_A32_UInt;
                 case VkFormat.R32Sfloat:
                     return PixelFormat.R32_Float;
                 case VkFormat.Bc3UnormBlock:


### PR DESCRIPTION
This PR implements `R8_G8_SNorm` and `R32_G32_B32_A32_UInt` pixel formats and hooks these new values up to the D3D11, Metal, Vulkan, and OpenGL backends.

I have added new tests, although I thought that with the growing number of pixel formats, it might be handy to have a single test that we can extend with new pixel formats, rather than copying-and-pasting?

I'll follow up with the BC1 and BC2 compressed formats in a separate PR.