### PR TITLE
Add Sdl2Window constructor that allows creation from an existing window handle

### DIFF
--- a/src/Veldrid.SDL2/Sdl2.Window.cs
+++ b/src/Veldrid.SDL2/Sdl2.Window.cs
@@ -11,6 +11,11 @@ namespace Veldrid.Sdl2
         public static SDL_Window SDL_CreateWindow(string title, int x, int y, int w, int h, SDL_WindowFlags flags) => s_sdl_createWindow(title, x, y, w, h, flags);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate SDL_Window SDL_CreateWindowFrom_t(IntPtr data);
+        private static SDL_CreateWindowFrom_t s_sdl_createWindowFrom = LoadFunction<SDL_CreateWindowFrom_t>("SDL_CreateWindowFrom");
+        public static SDL_Window SDL_CreateWindowFrom(IntPtr data) => s_sdl_createWindowFrom(data);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void SDL_DestroyWindow_t(SDL_Window SDL2Window);
         private static SDL_DestroyWindow_t s_sdl_destroyWindow = LoadFunction<SDL_DestroyWindow_t>("SDL_DestroyWindow");
         public static void SDL_DestroyWindow(SDL_Window Sdl2Window) => s_sdl_destroyWindow(Sdl2Window);


### PR DESCRIPTION
This PR adds an second `Sdl2Window` constructor that allows creation from an existing window handle.

This is useful for embedding into editor UIs - although AFAIK, Windows is the only platform where `SDL_CreateWindowFrom` accepts the handle of a non-window-level control, which limits its usefulness.

This is a speculative PR - I don't know whether this matches your vision for the `Sdl2Window` API. It would be really useful for me because I'd like to use the `Sdl2Window` abstraction, both for the game and also embedded in a (Windows-only-at-the-moment) editor.

My implementation could undoubtedly be improved, although because this is internal and there probably won't be a 3rd way to construct windows, I didn't want to over-engineer it.