### PR TITLE
Implement some additional helper state descriptions

### DIFF
--- a/src/Veldrid/BlendAttachmentDescription.cs
+++ b/src/Veldrid/BlendAttachmentDescription.cs
@@ -131,6 +131,28 @@ namespace Veldrid
         };
 
         /// <summary>
+        /// Describes a blend attachment state in which blending is disabled.
+        /// Settings:
+        ///     BlendEnabled = false
+        ///     SourceColorFactor = BlendFactor.One
+        ///     DestinationColorFactor = BlendFactor.Zero
+        ///     ColorFunction = BlendFunction.Add
+        ///     SourceAlphaFactor = BlendFactor.One
+        ///     DestinationAlphaFactor = BlendFactor.Zero
+        ///     AlphaFunction = BlendFunction.Add
+        /// </summary>
+        public static readonly BlendAttachmentDescription Disabled = new BlendAttachmentDescription
+        {
+            BlendEnabled = false,
+            SourceColorFactor = BlendFactor.One,
+            DestinationColorFactor = BlendFactor.Zero,
+            ColorFunction = BlendFunction.Add,
+            SourceAlphaFactor = BlendFactor.One,
+            DestinationAlphaFactor = BlendFactor.Zero,
+            AlphaFunction = BlendFunction.Add,
+        };
+
+        /// <summary>
         /// Element-wise equality.
         /// </summary>
         /// <param name="other">The instance to compare to.</param>

--- a/src/Veldrid/BlendStateDescription.cs
+++ b/src/Veldrid/BlendStateDescription.cs
@@ -46,6 +46,22 @@ namespace Veldrid
         };
 
         /// <summary>
+        /// Describes a blend state in which a single color target is blended with <see cref="BlendAttachmentDescription.AdditiveBlend"/>.
+        /// </summary>
+        public static readonly BlendStateDescription SingleAdditiveBlend = new BlendStateDescription
+        {
+            AttachmentStates = new BlendAttachmentDescription[] { BlendAttachmentDescription.AdditiveBlend }
+        };
+
+        /// <summary>
+        /// Describes a blend state in which a single color target is blended with <see cref="BlendAttachmentDescription.Disabled"/>.
+        /// </summary>
+        public static readonly BlendStateDescription SingleDisabled = new BlendStateDescription
+        {
+            AttachmentStates = new BlendAttachmentDescription[] { BlendAttachmentDescription.Disabled }
+        };
+
+        /// <summary>
         /// Describes an empty blend state in which no color targets are used.
         /// </summary>
         public static readonly BlendStateDescription Empty = new BlendStateDescription

--- a/src/Veldrid/DepthStencilStateDescription.cs
+++ b/src/Veldrid/DepthStencilStateDescription.cs
@@ -118,6 +118,21 @@ namespace Veldrid
         };
 
         /// <summary>
+        /// Describes a depth-only depth stencil state which uses a <see cref="ComparisonKind.LessEqual"/> comparison, and disables writing to the depth buffer.
+        /// The stencil test is disabled.
+        /// Settings:
+        ///     DepthTestEnabled = true
+        ///     DepthWriteEnabled = false
+        ///     ComparisonKind = DepthComparisonKind.LessEqual
+        /// </summary>
+        public static readonly DepthStencilStateDescription DepthOnlyLessEqualRead = new DepthStencilStateDescription
+        {
+            DepthTestEnabled = true,
+            DepthWriteEnabled = false,
+            DepthComparison = ComparisonKind.LessEqual
+        };
+
+        /// <summary>
         /// Describes a depth-only depth stencil state in which depth testing and writing is disabled.
         /// The stencil test is disabled.
         /// Settings:

--- a/src/Veldrid/RasterizerStateDescription.cs
+++ b/src/Veldrid/RasterizerStateDescription.cs
@@ -70,6 +70,25 @@ namespace Veldrid
         };
 
         /// <summary>
+        /// Describes a rasterizer state with no culling, solid polygon filling, and both depth
+        /// clipping and scissor tests enabled.
+        /// Settings:
+        ///     CullMode = FaceCullMode.None
+        ///     FillMode = PolygonFillMode.Solid
+        ///     FrontFace = FrontFace.Clockwise
+        ///     DepthClipEnabled = true
+        ///     ScissorTestEnabled = false
+        /// </summary>
+        public static readonly RasterizerStateDescription CullNone = new RasterizerStateDescription
+        {
+            CullMode = FaceCullMode.None,
+            FillMode = PolygonFillMode.Solid,
+            FrontFace = FrontFace.Clockwise,
+            DepthClipEnabled = true,
+            ScissorTestEnabled = false,
+        };
+
+        /// <summary>
         /// Element-wise equality.
         /// </summary>
         /// <param name="other">The instance to compare to.</param>


### PR DESCRIPTION
This PR adds these state descriptions:

* `BlendAttachmentDescription.Disabled`
* `BlendStateDescription.SingleAdditiveBlend`
* `BlendStateDescription.SingleDisabled`
* `DepthStencilStateDescription.DepthOnlyLessEqualRead`
* `RasterizerStateDescription.CullNone`

These are only quality-of-life improvements, nothing critical. XNA has all these and I personally find them useful.

Let me know if you'd like some but not others, and I can update the PR.