### PR TITLE
Fix structured buffer creation in D3D11 backend

### DIFF
--- a/src/Veldrid/D3D11/D3D11Buffer.cs
+++ b/src/Veldrid/D3D11/D3D11Buffer.cs
@@ -56,9 +56,9 @@ namespace Veldrid.D3D11
             {
                 ShaderResourceViewDescription srvDesc = new ShaderResourceViewDescription
                 {
-                    Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.ExtendedBuffer
+                    Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Buffer
                 };
-                srvDesc.BufferEx.ElementCount = (int)(SizeInBytes / structureByteStride);
+                srvDesc.Buffer.ElementCount = (int)(SizeInBytes / structureByteStride);
                 ShaderResourceView = new ShaderResourceView(device, _buffer, srvDesc);
             }
 


### PR DESCRIPTION
I'm not sure if I'm breaking some other usage with this change.

"Extended" buffer shader resource views appear to be raw views of bytes, which means that `BufferEx.ElementCount` is interpreted as the number of bytes. So in my usage, I was finding that the shader resource view for my structured buffer was clipped at N bytes, where N is the number of structures in the structured buffer.