### PR TITLE
[WIP] Allow null shader resources in resource sets

### DIFF
--- a/src/Veldrid/D3D11/D3D11Buffer.cs
+++ b/src/Veldrid/D3D11/D3D11Buffer.cs
@@ -56,9 +56,9 @@ namespace Veldrid.D3D11
             {
                 ShaderResourceViewDescription srvDesc = new ShaderResourceViewDescription
                 {
-                    Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.ExtendedBuffer
+                    Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Buffer
                 };
-                srvDesc.BufferEx.ElementCount = (int)(SizeInBytes / structureByteStride);
+                srvDesc.Buffer.ElementCount = (int)(SizeInBytes / structureByteStride);
                 ShaderResourceView = new ShaderResourceView(device, _buffer, srvDesc);
             }
 

--- a/src/Veldrid/D3D11/D3D11CommandList.cs
+++ b/src/Veldrid/D3D11/D3D11CommandList.cs
@@ -347,7 +347,9 @@ namespace Veldrid.D3D11
                         BindUniformBuffer(uniformBuffer, cbBase + rbi.Slot, rbi.Stages);
                         break;
                     case ResourceKind.StructuredBufferReadOnly:
-                        D3D11Buffer storageBufferRO = Util.AssertSubtype<BindableResource, D3D11Buffer>(resource);
+                        D3D11Buffer storageBufferRO = resource != null
+                            ? Util.AssertSubtype<BindableResource, D3D11Buffer>(resource)
+                            : null;
                         BindStorageBufferView(storageBufferRO, textureBase + rbi.Slot, rbi.Stages);
                         break;
                     case ResourceKind.StructuredBufferReadWrite:
@@ -355,8 +357,13 @@ namespace Veldrid.D3D11
                         BindUnorderedAccessView(null, storageBuffer.UnorderedAccessView, uaBase + rbi.Slot, rbi.Stages, slot);
                         break;
                     case ResourceKind.TextureReadOnly:
-                        D3D11TextureView texView = Util.AssertSubtype<BindableResource, D3D11TextureView>(resource);
-                        UnbindUAVTexture(texView.Target);
+                        D3D11TextureView texView = resource != null
+                            ? Util.AssertSubtype<BindableResource, D3D11TextureView>(resource)
+                            : null;
+                        if (texView != null)
+                        {
+                            UnbindUAVTexture(texView.Target);
+                        }
                         BindTextureView(texView, textureBase + rbi.Slot, rbi.Stages, slot);
                         break;
                     case ResourceKind.TextureReadWrite:
@@ -711,7 +718,7 @@ namespace Veldrid.D3D11
                 bool bind = false;
                 if (slot < MaxCachedUniformBuffers)
                 {
-                    if (_fragmentBoundTextureViews[slot] != texView)
+                    if (texView == null || _fragmentBoundTextureViews[slot] != texView)
                     {
                         _fragmentBoundTextureViews[slot] = texView;
                         bind = true;
@@ -749,7 +756,7 @@ namespace Veldrid.D3D11
         {
             _context.ComputeShader.SetUnorderedAccessView(0, null);
 
-            ShaderResourceView srv = storageBufferRO.ShaderResourceView;
+            ShaderResourceView srv = storageBufferRO?.ShaderResourceView;
             if ((stages & ShaderStages.Vertex) == ShaderStages.Vertex)
             {
                 _context.VertexShader.SetShaderResource(slot, srv);

--- a/src/Veldrid/D3D11/D3D11ResourceSet.cs
+++ b/src/Veldrid/D3D11/D3D11ResourceSet.cs
@@ -15,7 +15,7 @@
 
             foreach (BindableResource resource in description.BoundResources)
             {
-                if (!(resource is D3D11Buffer || resource is D3D11TextureView || resource is D3D11Sampler))
+                if (resource != null && (!(resource is D3D11Buffer || resource is D3D11TextureView || resource is D3D11Sampler)))
                 {
                     throw new VeldridException("Invalid resource type present in D3D11ResourceSet: " + resource.GetType().Name);
                 }

--- a/src/Veldrid/ResourceSet.cs
+++ b/src/Veldrid/ResourceSet.cs
@@ -42,6 +42,11 @@ namespace Veldrid
 #if VALIDATE_USAGE
         private void ValidateResourceKind(ResourceKind kind, BindableResource resource, uint slot)
         {
+            if (resource == null)
+            {
+                return;
+            }
+
             switch (kind)
             {
                 case ResourceKind.UniformBuffer:


### PR DESCRIPTION
(This builds on #33, so that should be merged before this one. And it should not be merged as-is, because I've only implemented this change for D3D11, and only for a subset of resource types. I wanted to get your feedback on the change before I go ahead with the other resource types and backends.)

This is different from #29 - that was about vertex buffers, and this is about shader resources (textures, structured buffers).

As far as I can tell, it *is* necessary to be able to unbind shader resources. Here's a simplified version of my use-case. I have two shaders, with these resource layouts:

```
Shader 1:
0: Texture2D
1: Texture2D

Shader 2:
0: Texture2D
1: StructuredBuffer (optional)
```

I first draw objects using Shader 1, then draw objects using Shader 2, in the same command list.

In Shader 2, the `StructuredBuffer` at slot 1 might not be present. The shader queries a value in a uniform buffer to see whether it should read from the structured buffer.

But because Veldrid doesn't allow bindable resources in a `ResourceSet` to be `null`, I can't "unbind" the `Texture2D` from Shader 1 slot 1, which causes the D3D11 debug layer to show a warning that a resource with the incorrect dimension (`Texture2D`) is bound at a slot where it expected a `StructuredBuffer`.

Do you agree with this change? If so I'll finish the implementation.