### PR TITLE
Added GFXAPI_VULKAN_ENABLED flag

### DIFF
--- a/src/Veldrid.StartupUtilities/Veldrid.StartupUtilities.csproj
+++ b/src/Veldrid.StartupUtilities/Veldrid.StartupUtilities.csproj
@@ -4,6 +4,7 @@
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);FEATURE_VULKAN_BACKEND</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -2,7 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using Veldrid.Vk;
 using Veldrid.Sdl2;
 using Veldrid.OpenGL;
 
@@ -98,7 +97,11 @@ namespace Veldrid.StartupUtilities
                 case GraphicsBackend.Direct3D11:
                     return CreateDefaultD3D11GraphicsDevice(options, window);
                 case GraphicsBackend.Vulkan:
+#if FEATURE_VULKAN_BACKEND
                     return CreateVulkanGraphicsDevice(options, window);
+#else
+                    throw new VeldridException("Vulkan support has not been included in this configuration of Veldrid");
+#endif
                 case GraphicsBackend.OpenGL:
                     return CreateDefaultOpenGLGraphicsDevice(options, window);
                 case GraphicsBackend.Metal:
@@ -139,34 +142,36 @@ namespace Veldrid.StartupUtilities
             }
         }
 
+#if FEATURE_VULKAN_BACKEND
         public static unsafe GraphicsDevice CreateVulkanGraphicsDevice(GraphicsDeviceOptions options, Sdl2Window window)
         {
             IntPtr sdlHandle = window.SdlWindowHandle;
             SDL_SysWMinfo sysWmInfo;
             Sdl2Native.SDL_GetVersion(&sysWmInfo.version);
             Sdl2Native.SDL_GetWMWindowInfo(sdlHandle, &sysWmInfo);
-            VkSurfaceSource surfaceSource = GetSurfaceSource(sysWmInfo);
+            Vk.VkSurfaceSource surfaceSource = GetSurfaceSource(sysWmInfo);
             GraphicsDevice gd = GraphicsDevice.CreateVulkan(options, surfaceSource, (uint)window.Width, (uint)window.Height);
 
             return gd;
         }
 
-        private static unsafe VkSurfaceSource GetSurfaceSource(SDL_SysWMinfo sysWmInfo)
+        private static unsafe Veldrid.Vk.VkSurfaceSource GetSurfaceSource(SDL_SysWMinfo sysWmInfo)
         {
             switch (sysWmInfo.subsystem)
             {
                 case SysWMType.Windows:
                     Win32WindowInfo w32Info = Unsafe.Read<Win32WindowInfo>(&sysWmInfo.info);
-                    return VkSurfaceSource.CreateWin32(w32Info.hinstance, w32Info.Sdl2Window);
+                    return Vk.VkSurfaceSource.CreateWin32(w32Info.hinstance, w32Info.Sdl2Window);
                 case SysWMType.X11:
                     X11WindowInfo x11Info = Unsafe.Read<X11WindowInfo>(&sysWmInfo.info);
-                    return VkSurfaceSource.CreateXlib(
+                    return Vk.VkSurfaceSource.CreateXlib(
                         (Vulkan.Xlib.Display*)x11Info.display,
                         new Vulkan.Xlib.Window() { Value = x11Info.Sdl2Window });
                 default:
                     throw new PlatformNotSupportedException("Cannot create a Vulkan surface for " + sysWmInfo.subsystem + ".");
             }
         }
+#endif
 
         public static unsafe GraphicsDevice CreateDefaultOpenGLGraphicsDevice(GraphicsDeviceOptions options, Sdl2Window window)
         {

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -529,7 +529,11 @@ namespace Veldrid
                 case GraphicsBackend.Direct3D11:
                     return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
                 case GraphicsBackend.Vulkan:
+#if FEATURE_VULKAN_BACKEND
                     return Vk.VkGraphicsDevice.IsSupported();
+#else
+                    return false;
+#endif
                 case GraphicsBackend.OpenGL:
                     return true;
                 case GraphicsBackend.Metal:
@@ -573,6 +577,7 @@ namespace Veldrid
             return new D3D11.D3D11GraphicsDevice(options, swapChainPanel, renderWidth, renderHeight, logicalDpi);
         }
 
+#if FEATURE_VULKAN_BACKEND
         /// <summary>
         /// Creates a new <see cref="GraphicsDevice"/> using Vulkan.
         /// </summary>
@@ -585,6 +590,7 @@ namespace Veldrid
         {
             return new Vk.VkGraphicsDevice(options, surfaceSource, width, height);
         }
+#endif
 
         /// <summary>
         /// Creates a new <see cref="GraphicsDevice"/> using OpenGL.

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>$(BinDir)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn Condition="'$(Configuration)' == 'Debug'">1591</NoWarn>
-    <DefineConstants>$(DefineConstants);VALIDATE_USAGE</DefineConstants>
+    <DefineConstants>$(DefineConstants);VALIDATE_USAGE;FEATURE_VULKAN_BACKEND</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,9 +16,13 @@
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.0.1" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.0.1" />
     <PackageReference Include="SharpDX.DXGI" Version="4.0.1" />
-    <PackageReference Include="Vk" Version="1.0.14" />
+    <PackageReference Include="Vk" Version="1.0.14" Condition="$(DefineConstants.Contains('FEATURE_VULKAN_BACKEND')) == 'true'" />
     <ProjectReference Include="..\Veldrid.OpenGLBindings\Veldrid.OpenGLBindings.csproj" />
     <ProjectReference Include="..\Veldrid.MetalBindings\Veldrid.MetalBindings.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Vk/*" Condition="$(DefineConstants.Contains('FEATURE_VULKAN_BACKEND')) == 'false'" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Allows you to cut Vulkan API support (if not defined) if you don't need it, also as addition you don't have to rely on Vk dependecy.