### PR TITLE
Added defines to exclude unneeded backends

### DIFF
--- a/src/Veldrid.StartupUtilities/Veldrid.StartupUtilities.csproj
+++ b/src/Veldrid.StartupUtilities/Veldrid.StartupUtilities.csproj
@@ -4,7 +4,7 @@
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>$(DefineConstants);FEATURE_VULKAN_BACKEND</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_VULKAN_BACKEND;FEATURE_D3D11_BACKEND;FEATURE_OPENGL_BACKEND;FEATURE_METAL_BACKEND</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Veldrid.Sdl2;
-using Veldrid.OpenGL;
 
 namespace Veldrid.StartupUtilities
 {
@@ -95,7 +94,11 @@ namespace Veldrid.StartupUtilities
             switch (preferredBackend)
             {
                 case GraphicsBackend.Direct3D11:
+#if FEATURE_D3D11_BACKEND
                     return CreateDefaultD3D11GraphicsDevice(options, window);
+#else
+                    throw new VeldridException("D3D11 support has not been included in this configuration of Veldrid");
+#endif
                 case GraphicsBackend.Vulkan:
 #if FEATURE_VULKAN_BACKEND
                     return CreateVulkanGraphicsDevice(options, window);
@@ -103,9 +106,17 @@ namespace Veldrid.StartupUtilities
                     throw new VeldridException("Vulkan support has not been included in this configuration of Veldrid");
 #endif
                 case GraphicsBackend.OpenGL:
+#if FEATURE_OPENGL_BACKEND
                     return CreateDefaultOpenGLGraphicsDevice(options, window);
+#else
+                    throw new VeldridException("OpenGL support has not been included in this configuration of Veldrid");
+#endif
                 case GraphicsBackend.Metal:
+#if FEATURE_METAL_BACKEND
                     return CreateMetalGraphicsDevice(options, window);
+#else
+                    throw new VeldridException("Metal support has not been included in this configuration of Veldrid");
+#endif
                 //case GraphicsBackend.OpenGLES:
                 //    return CreateDefaultOpenGLESRenderContext(ref contextCI, window);
                 default:
@@ -113,6 +124,7 @@ namespace Veldrid.StartupUtilities
             }
         }
 
+#if FEATURE_METAL_BACKEND
         private static unsafe GraphicsDevice CreateMetalGraphicsDevice(GraphicsDeviceOptions options, Sdl2Window window)
         {
             IntPtr sdlHandle = window.SdlWindowHandle;
@@ -123,6 +135,7 @@ namespace Veldrid.StartupUtilities
             IntPtr nsWindow = cocoaInfo.Window;
             return GraphicsDevice.CreateMetal(options, nsWindow);
         }
+#endif
 
         private static GraphicsBackend GetPlatformDefaultBackend()
         {
@@ -173,6 +186,7 @@ namespace Veldrid.StartupUtilities
         }
 #endif
 
+#if FEATURE_OPENGL_BACKEND
         public static unsafe GraphicsDevice CreateDefaultOpenGLGraphicsDevice(GraphicsDeviceOptions options, Sdl2Window window)
         {
             IntPtr sdlHandle = window.SdlWindowHandle;
@@ -221,7 +235,7 @@ namespace Veldrid.StartupUtilities
 
             int result = Sdl2Native.SDL_GL_SetSwapInterval(options.SyncToVerticalBlank ? 1 : 0);
 
-            OpenGLPlatformInfo platformInfo = new OpenGLPlatformInfo(
+            OpenGL.OpenGLPlatformInfo platformInfo = new OpenGL.OpenGLPlatformInfo(
                 contextHandle,
                 Sdl2Native.SDL_GL_GetProcAddress,
                 context => Sdl2Native.SDL_GL_MakeCurrent(sdlHandle, context),
@@ -237,11 +251,14 @@ namespace Veldrid.StartupUtilities
                 (uint)window.Width,
                 (uint)window.Height);
         }
+#endif
 
+#if FEATURE_D3D11_BACKEND
         public static GraphicsDevice CreateDefaultD3D11GraphicsDevice(GraphicsDeviceOptions options, Sdl2Window window)
         {
             return GraphicsDevice.CreateD3D11(options, window.Handle, (uint)window.Width, (uint)window.Height);
         }
+#endif
 
         private static unsafe string GetString(byte* stringStart)
         {

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -527,7 +527,11 @@ namespace Veldrid
             switch (backend)
             {
                 case GraphicsBackend.Direct3D11:
+#if FEATURE_D3D11_BACKEND
                     return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#else
+                    return false;
+#endif
                 case GraphicsBackend.Vulkan:
 #if FEATURE_VULKAN_BACKEND
                     return Vk.VkGraphicsDevice.IsSupported();
@@ -535,14 +539,23 @@ namespace Veldrid
                     return false;
 #endif
                 case GraphicsBackend.OpenGL:
+#if FEATURE_OPENGL_BACKEND
                     return true;
+#else
+                    return false;
+#endif
                 case GraphicsBackend.Metal:
+#if FEATURE_METAL_BACKEND
                     return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+#else
+                    return false;
+#endif
                 default:
                     throw Illegal.Value<GraphicsBackend>();
             }
         }
 
+#if FEATURE_D3D11_BACKEND
         /// <summary>
         /// Creates a new <see cref="GraphicsDevice"/> using Direct3D 11.
         /// </summary>
@@ -576,6 +589,7 @@ namespace Veldrid
         {
             return new D3D11.D3D11GraphicsDevice(options, swapChainPanel, renderWidth, renderHeight, logicalDpi);
         }
+#endif
 
 #if FEATURE_VULKAN_BACKEND
         /// <summary>
@@ -592,6 +606,7 @@ namespace Veldrid
         }
 #endif
 
+#if FEATURE_OPENGL_BACKEND
         /// <summary>
         /// Creates a new <see cref="GraphicsDevice"/> using OpenGL.
         /// </summary>
@@ -609,7 +624,9 @@ namespace Veldrid
         {
             return new OpenGL.OpenGLGraphicsDevice(options, platformInfo, width, height);
         }
+#endif
 
+#if FEATURE_METAL_BACKEND
         /// <summary>
         /// Creates a new <see cref="GraphicsDevice"/> using Metal.
         /// </summary>
@@ -623,5 +640,6 @@ namespace Veldrid
         {
             return new MTL.MTLGraphicsDevice(options, nsWindow);
         }
+#endif
     }
 }

--- a/src/Veldrid/Util.cs
+++ b/src/Veldrid/Util.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
-using Veldrid.D3D11;
 
 namespace Veldrid
 {

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -5,23 +5,27 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>$(BinDir)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn Condition="'$(Configuration)' == 'Debug'">1591</NoWarn>
-    <DefineConstants>$(DefineConstants);VALIDATE_USAGE;FEATURE_VULKAN_BACKEND</DefineConstants>
+    <DefineConstants>$(DefineConstants);VALIDATE_USAGE;FEATURE_VULKAN_BACKEND;FEATURE_D3D11_BACKEND;FEATURE_OPENGL_BACKEND;FEATURE_METAL_BACKEND</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Buffers" Version="4.4.0" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
-    <PackageReference Include="SharpDX" Version="4.0.1" />
-    <PackageReference Include="SharpDX.D3DCompiler" Version="4.0.1" />
-    <PackageReference Include="SharpDX.Direct3D11" Version="4.0.1" />
-    <PackageReference Include="SharpDX.DXGI" Version="4.0.1" />
+    <PackageReference Include="SharpDX" Version="4.0.1" Condition="$(DefineConstants.Contains('FEATURE_D3D11_BACKEND')) == 'true'" />
+    <PackageReference Include="SharpDX.D3DCompiler" Version="4.0.1" Condition="$(DefineConstants.Contains('FEATURE_D3D11_BACKEND')) == 'true'" />
+    <PackageReference Include="SharpDX.Direct3D11" Version="4.0.1" Condition="$(DefineConstants.Contains('FEATURE_D3D11_BACKEND')) == 'true'" />
+    <PackageReference Include="SharpDX.DXGI" Version="4.0.1" Condition="$(DefineConstants.Contains('FEATURE_D3D11_BACKEND')) == 'true'" />
     <PackageReference Include="Vk" Version="1.0.14" Condition="$(DefineConstants.Contains('FEATURE_VULKAN_BACKEND')) == 'true'" />
-    <ProjectReference Include="..\Veldrid.OpenGLBindings\Veldrid.OpenGLBindings.csproj" />
-    <ProjectReference Include="..\Veldrid.MetalBindings\Veldrid.MetalBindings.csproj" />
+    <ProjectReference Include="..\Veldrid.OpenGLBindings\Veldrid.OpenGLBindings.csproj" Condition="$(DefineConstants.Contains('FEATURE_OPENGL_BACKEND')) == 'true'" />
+    <ProjectReference Include="..\Veldrid.MetalBindings\Veldrid.MetalBindings.csproj" Condition="$(DefineConstants.Contains('FEATURE_METAL_BACKEND')) == 'true'" />
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="D3D11/*" Condition="$(DefineConstants.Contains('FEATURE_D3D11_BACKEND')) == 'false'" />
+    <Compile Remove="MTL/*" Condition="$(DefineConstants.Contains('FEATURE_METAL_BACKEND')) == 'false'" />
+    <Compile Remove="OpenGL/*/**" Condition="$(DefineConstants.Contains('FEATURE_OPENGL_BACKEND')) == 'false'" />
+    <Compile Remove="OpenGL/*" Condition="$(DefineConstants.Contains('FEATURE_OPENGL_BACKEND')) == 'false'" />
     <Compile Remove="Vk/*" Condition="$(DefineConstants.Contains('FEATURE_VULKAN_BACKEND')) == 'false'" />
   </ItemGroup>
 


### PR DESCRIPTION
Added defines FEATURE_D3D11_BACKEND, FEATURE_METAL_BACKEND, FEATURE_OPENGL_BACKEND, besides FEATURE_VULKAN_BACKEND. Allows you to individually disable backends that you don't need.