### PR TITLE
Fix the SwapchainDescription.SyncToVerticalBlank value being ignored

### DIFF
--- a/src/Veldrid/D3D11/D3D11Swapchain.cs
+++ b/src/Veldrid/D3D11/D3D11Swapchain.cs
@@ -41,6 +41,7 @@ namespace Veldrid.D3D11
         {
             _device = device;
             _depthFormat = description.DepthFormat;
+            SyncToVerticalBlank = description.SyncToVerticalBlank;
             if (description.Source is Win32SwapchainSource win32Source)
             {
                 SwapChainDescription dxgiSCDesc = new SwapChainDescription

--- a/src/Veldrid/MTL/MTLSwapchain.cs
+++ b/src/Veldrid/MTL/MTLSwapchain.cs
@@ -22,6 +22,7 @@ namespace Veldrid.MTL
         public MTLSwapchain(MTLGraphicsDevice gd, ref SwapchainDescription description)
         {
             _gd = gd;
+            SyncToVerticalBlank = description.SyncToVerticalBlank;
 
             _metalLayer = CAMetalLayer.New();
 

--- a/src/Veldrid/Vk/VkSwapchain.cs
+++ b/src/Veldrid/Vk/VkSwapchain.cs
@@ -44,6 +44,7 @@ namespace Veldrid.Vk
         public VkSwapchain(VkGraphicsDevice gd, ref SwapchainDescription description, VkSurfaceKHR existingSurface)
         {
             _gd = gd;
+            SyncToVerticalBlank = description.SyncToVerticalBlank;
 
             if (existingSurface == VkSurfaceKHR.Null)
             {


### PR DESCRIPTION
…when creating a Swapchain. Seems like a regression from 4.0.0.