### PR TITLE
Add configurable option to bind vertex data buffers after other vertex-stage uniform and structured buffers in Metal backend

### DIFF
--- a/src/Veldrid/GraphicsDeviceOptions.cs
+++ b/src/Veldrid/GraphicsDeviceOptions.cs
@@ -23,6 +23,11 @@
         /// Indicates whether the main Swapchain will be synchronized to the window system's vertical refresh rate.
         /// </summary>
         public bool SyncToVerticalBlank;
+        /// <summary>
+        /// Specifies which model the rendering backend should use for binding resources. This can be overridden per-pipeline
+        /// by specifying a value in <see cref="GraphicsPipelineDescription.ResourceBindingModel"/>.
+        /// </summary>
+        public ResourceBindingModel ResourceBindingModel;
 
         /// <summary>
         /// Constructs a new GraphicsDeviceOptions for a device with no main Swapchain.
@@ -35,6 +40,7 @@
             HasMainSwapchain = false;
             SwapchainDepthFormat = null;
             SyncToVerticalBlank = false;
+            ResourceBindingModel = ResourceBindingModel.Default;
         }
 
         /// <summary>
@@ -52,6 +58,7 @@
             HasMainSwapchain = true;
             SwapchainDepthFormat = swapchainDepthFormat;
             SyncToVerticalBlank = syncToVerticalBlank;
+            ResourceBindingModel = ResourceBindingModel.Default;
         }
     }
 }

--- a/src/Veldrid/GraphicsDeviceOptions.cs
+++ b/src/Veldrid/GraphicsDeviceOptions.cs
@@ -23,12 +23,6 @@
         /// Indicates whether the main Swapchain will be synchronized to the window system's vertical refresh rate.
         /// </summary>
         public bool SyncToVerticalBlank;
-        /// <summary>
-        /// If this value is true, vertex buffers will be bound in slot(s) after any other buffers (uniform, structured, etc.)
-        /// bound to the vertex stage. Default is false, which means vertex buffers will be bound in slot(s) starting from 0,
-        /// followed by any other buffers.
-        /// </summary>
-        public bool BindMetalVertexBuffersAfterOtherBuffers;
 
         /// <summary>
         /// Constructs a new GraphicsDeviceOptions for a device with no main Swapchain.
@@ -41,7 +35,6 @@
             HasMainSwapchain = false;
             SwapchainDepthFormat = null;
             SyncToVerticalBlank = false;
-            BindMetalVertexBuffersAfterOtherBuffers = false;
         }
 
         /// <summary>
@@ -59,7 +52,6 @@
             HasMainSwapchain = true;
             SwapchainDepthFormat = swapchainDepthFormat;
             SyncToVerticalBlank = syncToVerticalBlank;
-            BindMetalVertexBuffersAfterOtherBuffers = false;
         }
     }
 }

--- a/src/Veldrid/GraphicsDeviceOptions.cs
+++ b/src/Veldrid/GraphicsDeviceOptions.cs
@@ -23,6 +23,12 @@
         /// Indicates whether the main Swapchain will be synchronized to the window system's vertical refresh rate.
         /// </summary>
         public bool SyncToVerticalBlank;
+        /// <summary>
+        /// If this value is true, vertex buffers will be bound in slot(s) after any other buffers (uniform, structured, etc.)
+        /// bound to the vertex stage. Default is false, which means vertex buffers will be bound in slot(s) starting from 0,
+        /// followed by any other buffers.
+        /// </summary>
+        public bool BindMetalVertexBuffersAfterOtherBuffers;
 
         /// <summary>
         /// Constructs a new GraphicsDeviceOptions for a device with no main Swapchain.
@@ -35,6 +41,7 @@
             HasMainSwapchain = false;
             SwapchainDepthFormat = null;
             SyncToVerticalBlank = false;
+            BindMetalVertexBuffersAfterOtherBuffers = false;
         }
 
         /// <summary>
@@ -52,6 +59,7 @@
             HasMainSwapchain = true;
             SwapchainDepthFormat = swapchainDepthFormat;
             SyncToVerticalBlank = syncToVerticalBlank;
+            BindMetalVertexBuffersAfterOtherBuffers = false;
         }
     }
 }

--- a/src/Veldrid/GraphicsPipelineDescription.cs
+++ b/src/Veldrid/GraphicsPipelineDescription.cs
@@ -33,6 +33,10 @@ namespace Veldrid
         /// </summary>
         public ResourceLayout[] ResourceLayouts;
         /// <summary>
+        /// Specifies which model the rendering backend should use for binding resources.
+        /// </summary>
+        public ResourceBindingModel ResourceBindingModel;
+        /// <summary>
         /// A description of the output attachments used by the <see cref="Pipeline"/>.
         /// </summary>
         public OutputDescription Outputs;
@@ -67,6 +71,7 @@ namespace Veldrid
             PrimitiveTopology = primitiveTopology;
             ShaderSet = shaderSet;
             ResourceLayouts = resourceLayouts;
+            ResourceBindingModel = ResourceBindingModel.Default;
             Outputs = outputs;
         }
 
@@ -100,6 +105,7 @@ namespace Veldrid
             PrimitiveTopology = primitiveTopology;
             ShaderSet = shaderSet;
             ResourceLayouts = new[] { resourceLayout };
+            ResourceBindingModel = ResourceBindingModel.Default;
             Outputs = outputs;
         }
 
@@ -116,6 +122,7 @@ namespace Veldrid
                 && PrimitiveTopology == other.PrimitiveTopology
                 && ShaderSet.Equals(other.ShaderSet)
                 && Util.ArrayEquals(ResourceLayouts, other.ResourceLayouts)
+                && ResourceBindingModel.Equals(other.ResourceBindingModel)
                 && Outputs.Equals(other.Outputs);
         }
 
@@ -132,6 +139,7 @@ namespace Veldrid
                 PrimitiveTopology.GetHashCode(),
                 ShaderSet.GetHashCode(),
                 HashHelper.Array(ResourceLayouts),
+                ResourceBindingModel.GetHashCode(),
                 Outputs.GetHashCode());
         }
     }

--- a/src/Veldrid/GraphicsPipelineDescription.cs
+++ b/src/Veldrid/GraphicsPipelineDescription.cs
@@ -34,8 +34,9 @@ namespace Veldrid
         public ResourceLayout[] ResourceLayouts;
         /// <summary>
         /// Specifies which model the rendering backend should use for binding resources.
+        /// If <code>null</code>, the pipeline will use the value specified in <see cref="GraphicsDeviceOptions"/>.
         /// </summary>
-        public ResourceBindingModel ResourceBindingModel;
+        public ResourceBindingModel? ResourceBindingModel;
         /// <summary>
         /// A description of the output attachments used by the <see cref="Pipeline"/>.
         /// </summary>
@@ -71,7 +72,7 @@ namespace Veldrid
             PrimitiveTopology = primitiveTopology;
             ShaderSet = shaderSet;
             ResourceLayouts = resourceLayouts;
-            ResourceBindingModel = ResourceBindingModel.Default;
+            ResourceBindingModel = null;
             Outputs = outputs;
         }
 
@@ -105,7 +106,44 @@ namespace Veldrid
             PrimitiveTopology = primitiveTopology;
             ShaderSet = shaderSet;
             ResourceLayouts = new[] { resourceLayout };
-            ResourceBindingModel = ResourceBindingModel.Default;
+            ResourceBindingModel = null;
+            Outputs = outputs;
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="GraphicsPipelineDescription"/>.
+        /// </summary>
+        /// <param name="blendState">A description of the blend state, which controls how color values are blended into each
+        /// color target.</param>
+        /// <param name="depthStencilStateDescription">A description of the depth stencil state, which controls depth tests,
+        /// writing, and comparisons.</param>
+        /// <param name="rasterizerState">A description of the rasterizer state, which controls culling, clipping, scissor, and
+        /// polygon-fill behavior.</param>
+        /// <param name="primitiveTopology">The <see cref="PrimitiveTopology"/> to use, which controls how a series of input
+        /// vertices is interpreted by the <see cref="Pipeline"/>.</param>
+        /// <param name="shaderSet">A description of the shader set to be used.</param>
+        /// <param name="resourceLayouts">An array of <see cref="ResourceLayout"/>, which controls the layout of shader resoruces
+        /// in the <see cref="Pipeline"/>.</param>
+        /// <param name="resourceBindingModel">The <see cref="ResourceBindingModel"/> to use for this pipeline. Overrides
+        /// the value specified in <see cref="GraphicsDeviceOptions"/>.</param>
+        /// <param name="outputs">A description of the output attachments used by the <see cref="Pipeline"/>.</param>
+        public GraphicsPipelineDescription(
+            BlendStateDescription blendState,
+            DepthStencilStateDescription depthStencilStateDescription,
+            RasterizerStateDescription rasterizerState,
+            PrimitiveTopology primitiveTopology,
+            ShaderSetDescription shaderSet,
+            ResourceLayout[] resourceLayouts,
+            ResourceBindingModel resourceBindingModel,
+            OutputDescription outputs)
+        {
+            BlendState = blendState;
+            DepthStencilState = depthStencilStateDescription;
+            RasterizerState = rasterizerState;
+            PrimitiveTopology = primitiveTopology;
+            ShaderSet = shaderSet;
+            ResourceLayouts = resourceLayouts;
+            ResourceBindingModel = resourceBindingModel;
             Outputs = outputs;
         }
 

--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -183,7 +183,7 @@ namespace Veldrid.MTL
                 {
                     if (!_vertexBuffersActive[i])
                     {
-                        UIntPtr index = (UIntPtr)(_gd.BindMetalVertexBuffersAfterOtherBuffers
+                        UIntPtr index = (UIntPtr)(_graphicsPipeline.ResourceBindingModel == ResourceBindingModel.Improved
                             ? _nonVertexBufferCount + i
                             : i);
                         _rce.setVertexBuffer(
@@ -736,7 +736,7 @@ namespace Veldrid.MTL
             {
                 if ((stages & ShaderStages.Vertex) == ShaderStages.Vertex)
                 {
-                    UIntPtr index = (UIntPtr)(_gd.BindMetalVertexBuffersAfterOtherBuffers
+                    UIntPtr index = (UIntPtr)(_graphicsPipeline.ResourceBindingModel == ResourceBindingModel.Improved
                         ? slot + baseBuffer
                         : slot + _vertexBufferCount + baseBuffer);
                     _rce.setVertexBuffer(mtlBuffer.DeviceBuffer, UIntPtr.Zero, index);

--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -36,6 +36,7 @@ namespace Veldrid.MTL
         private ResourceSet[] _computeResourceSets;
         private bool[] _computeResourceSetsActive;
         private uint _vertexBufferCount;
+        private uint _nonVertexBufferCount;
         private MTLBuffer[] _vertexBuffers;
         private bool[] _vertexBuffersActive;
         private bool _disposed;
@@ -182,7 +183,13 @@ namespace Veldrid.MTL
                 {
                     if (!_vertexBuffersActive[i])
                     {
-                        _rce.setVertexBuffer(_vertexBuffers[i].DeviceBuffer, UIntPtr.Zero, (UIntPtr)i);
+                        UIntPtr index = (UIntPtr)(_gd.BindMetalVertexBuffersAfterOtherBuffers
+                            ? _nonVertexBufferCount + i
+                            : i);
+                        _rce.setVertexBuffer(
+                            _vertexBuffers[i].DeviceBuffer, 
+                            UIntPtr.Zero, 
+                            index);
                     }
                 }
                 return true;
@@ -269,6 +276,8 @@ namespace Veldrid.MTL
                 Util.EnsureArrayMinimumSize(ref _graphicsResourceSets, _graphicsResourceSetCount);
                 Util.EnsureArrayMinimumSize(ref _graphicsResourceSetsActive, _graphicsResourceSetCount);
                 Util.ClearArray(_graphicsResourceSetsActive);
+
+                _nonVertexBufferCount = _graphicsPipeline.NonVertexBufferCount;
 
                 _vertexBufferCount = _graphicsPipeline.VertexBufferCount;
                 Util.EnsureArrayMinimumSize(ref _vertexBuffers, _vertexBufferCount);
@@ -727,8 +736,10 @@ namespace Veldrid.MTL
             {
                 if ((stages & ShaderStages.Vertex) == ShaderStages.Vertex)
                 {
-                    uint vertexBufferCount = _graphicsPipeline.VertexBufferCount;
-                    _rce.setVertexBuffer(mtlBuffer.DeviceBuffer, UIntPtr.Zero, (UIntPtr)(slot + vertexBufferCount + baseBuffer));
+                    UIntPtr index = (UIntPtr)(_gd.BindMetalVertexBuffersAfterOtherBuffers
+                        ? slot + baseBuffer
+                        : slot + _vertexBufferCount + baseBuffer);
+                    _rce.setVertexBuffer(mtlBuffer.DeviceBuffer, UIntPtr.Zero, index);
                 }
                 if ((stages & ShaderStages.Fragment) == ShaderStages.Fragment)
                 {

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -33,6 +33,7 @@ namespace Veldrid.MTL
         public MTLDevice Device => _device;
         public MTLCommandQueue CommandQueue => _commandQueue;
         public MTLFeatureSupport MetalFeatures { get; }
+        public ResourceBindingModel ResourceBindingModel { get; }
 
         public MTLGraphicsDevice(
             GraphicsDeviceOptions options,
@@ -53,6 +54,7 @@ namespace Veldrid.MTL
                 depthClipDisable: true,
                 texture1D: true, // TODO: Should be macOS 10.11+ and iOS 11.0+.
                 independentBlend: true);
+            ResourceBindingModel = options.ResourceBindingModel;
 
             ResourceFactory = new MTLResourceFactory(this);
             _commandQueue = _device.newCommandQueue();

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -34,8 +34,6 @@ namespace Veldrid.MTL
         public MTLCommandQueue CommandQueue => _commandQueue;
         public MTLFeatureSupport MetalFeatures { get; }
 
-        public bool BindMetalVertexBuffersAfterOtherBuffers { get; }
-
         public MTLGraphicsDevice(
             GraphicsDeviceOptions options,
             SwapchainDescription? swapchainDesc)
@@ -73,8 +71,6 @@ namespace Veldrid.MTL
                 SwapchainDescription desc = swapchainDesc.Value;
                 _mainSwapchain = new MTLSwapchain(this, ref desc);
             }
-
-            BindMetalVertexBuffersAfterOtherBuffers = options.BindMetalVertexBuffersAfterOtherBuffers;
 
             PostDeviceCreated();
         }

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -34,6 +34,8 @@ namespace Veldrid.MTL
         public MTLCommandQueue CommandQueue => _commandQueue;
         public MTLFeatureSupport MetalFeatures { get; }
 
+        public bool BindMetalVertexBuffersAfterOtherBuffers { get; }
+
         public MTLGraphicsDevice(
             GraphicsDeviceOptions options,
             SwapchainDescription? swapchainDesc)
@@ -71,6 +73,8 @@ namespace Veldrid.MTL
                 SwapchainDescription desc = swapchainDesc.Value;
                 _mainSwapchain = new MTLSwapchain(this, ref desc);
             }
+
+            BindMetalVertexBuffersAfterOtherBuffers = options.BindMetalVertexBuffersAfterOtherBuffers;
 
             PostDeviceCreated();
         }

--- a/src/Veldrid/MTL/MTLPipeline.cs
+++ b/src/Veldrid/MTL/MTLPipeline.cs
@@ -12,6 +12,7 @@ namespace Veldrid.MTL
         public MTLComputePipelineState ComputePipelineState { get; }
         public MTLPrimitiveType PrimitiveType { get; }
         public MTLResourceLayout[] ResourceLayouts { get; }
+        public ResourceBindingModel ResourceBindingModel { get; }
         public uint VertexBufferCount { get; }
         public uint NonVertexBufferCount { get; }
         public MTLCullMode CullMode { get; }
@@ -38,6 +39,7 @@ namespace Veldrid.MTL
                 ResourceLayouts[i] = Util.AssertSubtype<ResourceLayout, MTLResourceLayout>(description.ResourceLayouts[i]);
                 NonVertexBufferCount += ResourceLayouts[i].BufferCount;
             }
+            ResourceBindingModel = description.ResourceBindingModel;
 
             CullMode = MTLFormats.VdToMTLCullMode(description.RasterizerState.CullMode);
             FrontFace = MTLFormats.VdVoMTLFrontFace(description.RasterizerState.FrontFace);
@@ -80,7 +82,7 @@ namespace Veldrid.MTL
                 {
                     VertexElementDescription elementDesc = vdDesc.Elements[j];
                     MTLVertexAttributeDescriptor mtlAttribute = vertexDescriptor.attributes[element];
-                    mtlAttribute.bufferIndex = (UIntPtr)(gd.BindMetalVertexBuffersAfterOtherBuffers
+                    mtlAttribute.bufferIndex = (UIntPtr)(description.ResourceBindingModel == ResourceBindingModel.Improved
                         ? NonVertexBufferCount + i
                         : i);
                     mtlAttribute.format = MTLFormats.VdToMTLVertexFormat(elementDesc.Format);

--- a/src/Veldrid/MTL/MTLPipeline.cs
+++ b/src/Veldrid/MTL/MTLPipeline.cs
@@ -13,6 +13,7 @@ namespace Veldrid.MTL
         public MTLPrimitiveType PrimitiveType { get; }
         public MTLResourceLayout[] ResourceLayouts { get; }
         public uint VertexBufferCount { get; }
+        public uint NonVertexBufferCount { get; }
         public MTLCullMode CullMode { get; }
         public MTLWinding FrontFace { get; }
         public MTLTriangleFillMode FillMode { get; }
@@ -31,9 +32,11 @@ namespace Veldrid.MTL
         {
             PrimitiveType = MTLFormats.VdToMTLPrimitiveTopology(description.PrimitiveTopology);
             ResourceLayouts = new MTLResourceLayout[description.ResourceLayouts.Length];
+            NonVertexBufferCount = 0;
             for (int i = 0; i < ResourceLayouts.Length; i++)
             {
                 ResourceLayouts[i] = Util.AssertSubtype<ResourceLayout, MTLResourceLayout>(description.ResourceLayouts[i]);
+                NonVertexBufferCount += ResourceLayouts[i].BufferCount;
             }
 
             CullMode = MTLFormats.VdToMTLCullMode(description.RasterizerState.CullMode);
@@ -77,7 +80,9 @@ namespace Veldrid.MTL
                 {
                     VertexElementDescription elementDesc = vdDesc.Elements[j];
                     MTLVertexAttributeDescriptor mtlAttribute = vertexDescriptor.attributes[element];
-                    mtlAttribute.bufferIndex = (UIntPtr)i;
+                    mtlAttribute.bufferIndex = (UIntPtr)(gd.BindMetalVertexBuffersAfterOtherBuffers
+                        ? NonVertexBufferCount + i
+                        : i);
                     mtlAttribute.format = MTLFormats.VdToMTLVertexFormat(elementDesc.Format);
                     mtlAttribute.offset = (UIntPtr)offset;
                     offset += FormatHelpers.GetSizeInBytes(elementDesc.Format);

--- a/src/Veldrid/MTL/MTLPipeline.cs
+++ b/src/Veldrid/MTL/MTLPipeline.cs
@@ -39,7 +39,7 @@ namespace Veldrid.MTL
                 ResourceLayouts[i] = Util.AssertSubtype<ResourceLayout, MTLResourceLayout>(description.ResourceLayouts[i]);
                 NonVertexBufferCount += ResourceLayouts[i].BufferCount;
             }
-            ResourceBindingModel = description.ResourceBindingModel;
+            ResourceBindingModel = description.ResourceBindingModel ?? gd.ResourceBindingModel;
 
             CullMode = MTLFormats.VdToMTLCullMode(description.RasterizerState.CullMode);
             FrontFace = MTLFormats.VdVoMTLFrontFace(description.RasterizerState.FrontFace);
@@ -82,7 +82,7 @@ namespace Veldrid.MTL
                 {
                     VertexElementDescription elementDesc = vdDesc.Elements[j];
                     MTLVertexAttributeDescriptor mtlAttribute = vertexDescriptor.attributes[element];
-                    mtlAttribute.bufferIndex = (UIntPtr)(description.ResourceBindingModel == ResourceBindingModel.Improved
+                    mtlAttribute.bufferIndex = (UIntPtr)(ResourceBindingModel == ResourceBindingModel.Improved
                         ? NonVertexBufferCount + i
                         : i);
                     mtlAttribute.format = MTLFormats.VdToMTLVertexFormat(elementDesc.Format);

--- a/src/Veldrid/ResourceBindingModel.cs
+++ b/src/Veldrid/ResourceBindingModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Veldrid
+{
+    public enum ResourceBindingModel
+    {
+        Default = 0,
+        Improved = 1,
+    }
+}


### PR DESCRIPTION
Matches the behaviour change in https://github.com/mellinoe/ShaderGen/pull/36.

`BindMetalVertexBuffersAfterOtherBuffers` is obviously just a placeholder name - do you have suggestions for a better name?