### PR TITLE
Add missing depth buffer formats to the OpenGL backend

### DIFF
--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -232,7 +232,7 @@ namespace Veldrid.StartupUtilities
             if (backend == GraphicsBackend.OpenGL)
             {
                 Sdl2Native.SDL_GL_SetAttribute(SDL_GLAttribute.ContextProfileMask, (int)SDL_GLProfile.Core);
-            Sdl2Native.SDL_GL_SetAttribute(SDL_GLAttribute.ContextMajorVersion, 3);
+                Sdl2Native.SDL_GL_SetAttribute(SDL_GLAttribute.ContextMajorVersion, 3);
                 Sdl2Native.SDL_GL_SetAttribute(SDL_GLAttribute.ContextMinorVersion, 0);
             }
             else
@@ -246,10 +246,14 @@ namespace Veldrid.StartupUtilities
             if (options.SwapchainDepthFormat.HasValue)
             {
                 switch (options.SwapchainDepthFormat)
-                {
+                { 
                     case PixelFormat.R16_UNorm:
                         depthBits = 16;
                         break;
+                    case PixelFormat.D24_UNorm_S8_UInt:
+                        depthBits = 24;
+                    break;
+                    case PixelFormat.D32_Float_S8_UInt:
                     case PixelFormat.R32_Float:
                         depthBits = 32;
                         break;

--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -243,6 +243,7 @@ namespace Veldrid.StartupUtilities
             }
 
             int depthBits = 0;
+            int stencilBits = 0;
             if (options.SwapchainDepthFormat.HasValue)
             {
                 switch (options.SwapchainDepthFormat)
@@ -252,16 +253,21 @@ namespace Veldrid.StartupUtilities
                         break;
                     case PixelFormat.D24_UNorm_S8_UInt:
                         depthBits = 24;
-                    break;
-                    case PixelFormat.D32_Float_S8_UInt:
+                        stencilBits = 8;
+                    break;           
                     case PixelFormat.R32_Float:
                         depthBits = 32;
+                        break;
+                    case PixelFormat.D32_Float_S8_UInt:
+                        depthBits = 32;
+                        stencilBits = 8;
                         break;
                     default:
                         throw new VeldridException("Invalid depth format: " + options.SwapchainDepthFormat.Value);
                 }
             }
 
+            Sdl2Native.SDL_GL_SetAttribute(SDL_GLAttribute.StencilSize, stencilBits);
             Sdl2Native.SDL_GL_SetAttribute(SDL_GLAttribute.DepthSize, depthBits);
 
             IntPtr contextHandle = Sdl2Native.SDL_GL_CreateContext(sdlHandle);

--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -247,7 +247,7 @@ namespace Veldrid.StartupUtilities
             if (options.SwapchainDepthFormat.HasValue)
             {
                 switch (options.SwapchainDepthFormat)
-                { 
+                {
                     case PixelFormat.R16_UNorm:
                         depthBits = 16;
                         break;
@@ -267,8 +267,8 @@ namespace Veldrid.StartupUtilities
                 }
             }
 
-            Sdl2Native.SDL_GL_SetAttribute(SDL_GLAttribute.StencilSize, stencilBits);
             Sdl2Native.SDL_GL_SetAttribute(SDL_GLAttribute.DepthSize, depthBits);
+            Sdl2Native.SDL_GL_SetAttribute(SDL_GLAttribute.StencilSize, stencilBits);
 
             IntPtr contextHandle = Sdl2Native.SDL_GL_CreateContext(sdlHandle);
             if (contextHandle == IntPtr.Zero)


### PR DESCRIPTION
Those formats were supported by all other backends, but still missing for the OpenGL backend.