### PR TITLE
Make VeldridStartup.GetPlatformDefaultBackend public

### DIFF
--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -172,7 +172,7 @@ namespace Veldrid.StartupUtilities
         }
 #endif
 
-        private static GraphicsBackend GetPlatformDefaultBackend()
+        public static GraphicsBackend GetPlatformDefaultBackend()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {


### PR DESCRIPTION
In our game, the user can optionally override the renderer backend. But because there's no overload of `CreateWindowAndGraphicsDevice` that accepts a `GraphicsBackend?`, we need to conditionally call the overload that does / doesn't accept a `GraphicsBackend`.

With this change, we can do this:

``` csharp
GraphicsBackend? preferredBackend = null;
if (something)
{
    preferredBackend = GraphicsBackend.Direct3D11; // read from CLI argument
}
VeldridStartup.CreateWindowAndGraphicsDevice(
    windowCreateInfo,
    graphicsDeviceOptions,
    preferredBackend ?? VeldridStartup.GetPlatformDefaultBackend(),
    out _window,
    out _device);
```