### PR TITLE
Rewrite StagingMemoryPool to use unmanaged memory blocks

### DIFF
--- a/src/Veldrid/OpenGL/NoAllocEntryList/NoAllocUpdateBufferEntry.cs
+++ b/src/Veldrid/OpenGL/NoAllocEntryList/NoAllocUpdateBufferEntry.cs
@@ -4,10 +4,10 @@
     {
         public readonly Tracked<DeviceBuffer> Buffer;
         public readonly uint BufferOffsetInBytes;
-        public readonly Tracked<byte[]> StagingBlock;
+        public readonly StagingBlock StagingBlock;
         public readonly uint StagingBlockSize;
 
-        public NoAllocUpdateBufferEntry(Tracked<DeviceBuffer> buffer, uint bufferOffsetInBytes, Tracked<byte[]> stagingBlock, uint stagingBlockSize)
+        public NoAllocUpdateBufferEntry(Tracked<DeviceBuffer> buffer, uint bufferOffsetInBytes, StagingBlock stagingBlock, uint stagingBlockSize)
         {
             Buffer = buffer;
             BufferOffsetInBytes = bufferOffsetInBytes;

--- a/src/Veldrid/OpenGL/NoAllocEntryList/OpenGLNoAllocCommandEntryList.cs
+++ b/src/Veldrid/OpenGL/NoAllocEntryList/OpenGLNoAllocCommandEntryList.cs
@@ -122,9 +122,10 @@ namespace Veldrid.OpenGL.NoAllocEntryList
 
         private void FlushStagingBlocks()
         {
+            StagingMemoryPool pool = _memoryPool;
             foreach (StagingBlock block in _stagingBlocks)
             {
-                block.Free();
+                pool.Free(block);
             }
 
             _stagingBlocks.Clear();

--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -1399,7 +1399,7 @@ namespace Veldrid.OpenGL
                     width, height, 1,
                     dstMipLevel, dstLayer);
 
-                trueCopySrc.Free();
+                _stagingMemoryPool.Free(trueCopySrc);
             }
             else // !isCompressed
             {
@@ -1450,7 +1450,7 @@ namespace Veldrid.OpenGL
                         width, height, depth,
                         srcGLTexture.Format);
 
-                    fullBlock.Free();
+                    _stagingMemoryPool.Free(fullBlock);
                 }
 
                 UpdateTexture(
@@ -1466,7 +1466,7 @@ namespace Veldrid.OpenGL
                 CheckLastError();
             }
 
-            block.Free();
+            _stagingMemoryPool.Free(block);
         }
 
         private static void CopyWithFBO(

--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -1329,7 +1329,7 @@ namespace Veldrid.OpenGL
                 sizeInBytes = width * height * depth * pixelSize;
             }
 
-            FixedStagingBlock block = _stagingMemoryPool.GetFixedStagingBlock(sizeInBytes);
+            StagingBlock block = _stagingMemoryPool.GetStagingBlock(sizeInBytes);
 
             if (packAlignment < 4)
             {
@@ -1379,7 +1379,7 @@ namespace Veldrid.OpenGL
                 uint denseDepthPitch = FormatHelpers.GetDepthPitch(denseRowPitch, height, srcGLTexture.Format);
                 uint numRows = FormatHelpers.GetNumRows(height, srcGLTexture.Format);
                 uint trueCopySize = denseRowPitch * numRows;
-                FixedStagingBlock trueCopySrc = _stagingMemoryPool.GetFixedStagingBlock(trueCopySize);
+                StagingBlock trueCopySrc = _stagingMemoryPool.GetStagingBlock(trueCopySize);
 
                 Util.CopyTextureRegion(
                     block.Data,
@@ -1419,7 +1419,7 @@ namespace Veldrid.OpenGL
                     Util.GetMipDimensions(srcGLTexture, srcMipLevel, out uint mipWidth, out uint mipHeight, out uint mipDepth);
                     uint fullMipSize = mipWidth * mipHeight * mipDepth * srcGLTexture.ArrayLayers * pixelSize;
 
-                    FixedStagingBlock fullBlock = _stagingMemoryPool.GetFixedStagingBlock(fullMipSize);
+                    StagingBlock fullBlock = _stagingMemoryPool.GetStagingBlock(fullMipSize);
 
                     _textureSamplerManager.SetTextureTransient(srcTarget, srcGLTexture.Texture);
                     CheckLastError();

--- a/src/Veldrid/OpenGL/OpenGLCommandList.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandList.cs
@@ -11,6 +11,7 @@ namespace Veldrid.OpenGL
         private OpenGLCommandEntryList _currentCommands;
 
         internal OpenGLCommandEntryList CurrentCommands => _currentCommands;
+        internal OpenGLGraphicsDevice Device => _gd;
 
         private readonly object _lock = new object();
         private readonly List<OpenGLCommandEntryList> _availableLists = new List<OpenGLCommandEntryList>();

--- a/src/Veldrid/OpenGL/OpenGLResourceFactory.cs
+++ b/src/Veldrid/OpenGL/OpenGLResourceFactory.cs
@@ -8,7 +8,7 @@ namespace Veldrid.OpenGL
     internal class OpenGLResourceFactory : ResourceFactory
     {
         private readonly OpenGLGraphicsDevice _gd;
-        private readonly StagingMemoryPool _pool = new StagingMemoryPool();
+        private readonly StagingMemoryPool _pool;
 
         public override GraphicsBackend BackendType => _gd.BackendType;
 
@@ -16,6 +16,7 @@ namespace Veldrid.OpenGL
             : base(gd.Features)
         {
             _gd = gd;
+            _pool = gd.StagingMemoryPool;
         }
 
         public override CommandList CreateCommandList(ref CommandListDescription description)

--- a/src/Veldrid/OpenGL/OpenGLShader.cs
+++ b/src/Veldrid/OpenGL/OpenGLShader.cs
@@ -97,7 +97,7 @@ namespace Veldrid.OpenGL
                 throw new VeldridException($"Unable to compile shader code for shader [{_name}] of type {_shaderType}: {message}");
             }
 
-            _stagingBlock.Free();
+            _gd.StagingMemoryPool.Free(_stagingBlock);
             Created = true;
         }
 
@@ -111,8 +111,15 @@ namespace Veldrid.OpenGL
             if (!_disposed)
             {
                 _disposed = true;
-                glDeleteShader(_shader);
-                CheckLastError();
+                if (Created)
+                {
+                    glDeleteShader(_shader);
+                    CheckLastError();
+                }
+                else
+                {
+                    _gd.StagingMemoryPool.Free(_stagingBlock);
+                }
             }
         }
     }

--- a/src/Veldrid/OpenGL/OpenGLShader.cs
+++ b/src/Veldrid/OpenGL/OpenGLShader.cs
@@ -65,14 +65,11 @@ namespace Veldrid.OpenGL
             _shader = glCreateShader(_shaderType);
             CheckLastError();
 
-            fixed (byte* arrayPtr = &_stagingBlock.Array[0])
-            {
-                byte* textPtr = arrayPtr;
-                int length = (int)_stagingBlock.SizeInBytes;
-                byte** textsPtr = &textPtr;
+            byte* textPtr = (byte*)_stagingBlock.Data;
+            int length = (int)_stagingBlock.SizeInBytes;
+            byte** textsPtr = &textPtr;
 
-                glShaderSource(_shader, 1, textsPtr, &length);
-            }
+            glShaderSource(_shader, 1, textsPtr, &length);
             CheckLastError();
 
             glCompileShader(_shader);

--- a/src/Veldrid/StagingMemoryPool.cs
+++ b/src/Veldrid/StagingMemoryPool.cs
@@ -1,113 +1,132 @@
 ﻿using System;
-using System.Buffers;
-using System.Diagnostics;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Veldrid
 {
-    internal unsafe class StagingMemoryPool
+    internal unsafe sealed class StagingMemoryPool : IDisposable
     {
-        private readonly ArrayPool<byte> _arrayPool = ArrayPool<byte>.Shared;
+        private readonly List<StagingBlock> _storage;
+        private readonly SortedList<uint, uint> _availableBlocks;
+        private object _lock = new object();
+
+        public StagingMemoryPool()
+        {
+            _storage = new List<StagingBlock>();
+            _availableBlocks = new SortedList<uint, uint>(new CapacityComparer());
+        }
 
         public StagingBlock Stage(IntPtr source, uint sizeInBytes)
         {
-            byte[] array = _arrayPool.Rent((int)sizeInBytes);
-            fixed (byte* arrayPtr = &array[0])
-            {
-                Debug.Assert(array.Length >= sizeInBytes);
-                Unsafe.CopyBlock(arrayPtr, source.ToPointer(), sizeInBytes);
-            }
-
-            return new StagingBlock(array, sizeInBytes, this);
+            Rent(sizeInBytes, out StagingBlock block);
+            Unsafe.CopyBlock(block.Data, source.ToPointer(), sizeInBytes);
+            return block;
         }
 
         public StagingBlock Stage(byte[] bytes)
         {
-            byte[] array = _arrayPool.Rent(bytes.Length);
-            Array.Copy(bytes, array, bytes.Length);
-            return new StagingBlock(array, (uint)bytes.Length, this);
+            Rent((uint)bytes.Length, out StagingBlock block);
+            Marshal.Copy(bytes, 0, (IntPtr)block.Data, bytes.Length);
+            return block;
         }
 
-        public FixedStagingBlock GetFixedStagingBlock(uint sizeInBytes)
+        public StagingBlock GetStagingBlock(uint sizeInBytes)
         {
-            byte[] array = _arrayPool.Rent((int)sizeInBytes);
-            return new FixedStagingBlock(array, sizeInBytes, this);
+            Rent(sizeInBytes, out StagingBlock block);
+            Unsafe.InitBlock(block.Data, 0, sizeInBytes);
+            return block;
+        }
+
+        public StagingBlock RetrieveById(uint id)
+        {
+            return _storage[(int)id];
+        }
+
+        private void Rent(uint size, out StagingBlock block)
+        {
+            lock (_lock)
+            {
+                SortedList<uint, uint> available = _availableBlocks;
+                IList<uint> indices = available.Values;
+                for (int i = 0; i < available.Count; i++)
+                {
+                    int index = (int)indices[i];
+                    StagingBlock current = _storage[index];
+                    if (current.Capacity >= size)
+                    {
+                        available.RemoveAt(i);
+                        current.SizeInBytes = size;
+                        block = current;
+                        _storage[index] = current;
+                        return;
+                    }
+                }
+
+                Allocate(size, out block);
+            }
+        }
+
+        private void Allocate(uint sizeInBytes, out StagingBlock stagingBlock)
+        {
+            IntPtr ptr = Marshal.AllocHGlobal((int)sizeInBytes);
+            uint id = (uint)_storage.Count;
+            stagingBlock = new StagingBlock(id, (void*)ptr, sizeInBytes, this);
+            _storage.Add(stagingBlock);
         }
 
         public void Free(StagingBlock block)
         {
-            bool clearArray = false;
-#if DEBUG
-            clearArray = true;
-#endif
-            _arrayPool.Return(block.Array, clearArray);
+            lock (_lock)
+            {
+                if (block.Id < _storage.Count)
+                {
+                    _availableBlocks.Add(block.Capacity, block.Id);
+                }
+            }
         }
 
-        public void Free(FixedStagingBlock block)
+        public void Dispose()
         {
-            bool clearArray = false;
-#if DEBUG
-            clearArray = true;
-#endif
-            _arrayPool.Return(block.Array, clearArray);
+            lock (_lock)
+            {
+                _availableBlocks.Clear();
+                foreach (StagingBlock block in _storage)
+                {
+                    Marshal.FreeHGlobal((IntPtr)block.Data);
+                }
+                _storage.Clear();
+            }
         }
 
-        public void Free(byte[] array)
+        private class CapacityComparer : IComparer<uint>
         {
-            bool clearArray = false;
-#if DEBUG
-            clearArray = true;
-#endif
-            _arrayPool.Return(array, clearArray);
+            public int Compare(uint x, uint y)
+            {
+                return x >= y ? 1 : -1;
+            }
         }
     }
 
     internal unsafe struct StagingBlock
     {
-        public readonly byte[] Array;
-        public readonly uint SizeInBytes;
-        public readonly StagingMemoryPool Pool;
-
-        public StagingBlock(byte[] array, uint sizeInBytes, StagingMemoryPool pool)
-        {
-            Debug.Assert(array != null);
-            Debug.Assert(array.Length > 0);
-            Debug.Assert(sizeInBytes > 0);
-            Array = array;
-            SizeInBytes = sizeInBytes;
-            Pool = pool;
-        }
-
-        internal void Free()
-        {
-            Pool.Free(this);
-        }
-    }
-
-    internal unsafe struct FixedStagingBlock
-    {
-        public readonly byte[] Array;
-        public readonly uint SizeInBytes;
-        public readonly StagingMemoryPool Pool;
-        public readonly GCHandle GCHandle;
+        public readonly uint Id;
         public readonly void* Data;
+        public readonly uint Capacity;
+        public uint SizeInBytes;
+        public readonly StagingMemoryPool Pool;
 
-        public FixedStagingBlock(byte[] array, uint sizeInBytes, StagingMemoryPool pool)
+        public StagingBlock(uint id, void* data, uint capacity, StagingMemoryPool pool)
         {
-            Debug.Assert(array != null);
-            Debug.Assert(array.Length > 0);
-            Debug.Assert(sizeInBytes > 0);
-            Array = array;
-            SizeInBytes = sizeInBytes;
+            Id = id;
+            Data = data;
+            Capacity = capacity;
+            SizeInBytes = capacity;
             Pool = pool;
-            GCHandle = GCHandle.Alloc(array, GCHandleType.Pinned);
-            Data = (void*)GCHandle.AddrOfPinnedObject();
         }
 
-        internal void Free()
+        public void Free()
         {
-            GCHandle.Free();
             Pool.Free(this);
         }
     }


### PR DESCRIPTION
This change noticeably improves performance (mainly) in scenarios that involve lots of texture updates, such as video playback.

A few things to note:
- The pool returns *the smallest* block that is big enough to store the requested amount of data.
- ``GraphicsDevice`` now owns (the only instance of) the pool.
- ``StagingMemoryPool`` now has a ``Dispose`` method which frees all the native memory. The execution thread is responsible for calling it.
- Each ``CommandList`` has its own list of staging blocks, which is flushed when the ``CommandList`` is disposed. This presents a problem if a ``CommandList`` is disposed after the ``GraphicsDevice``, which owns the memory pool. This is currently addressed by adding [this check](https://github.com/SomeAnon42/veldrid/blob/c6f73d4e11dfbbf825adff2e8b91c4e6dddb160e/src/Veldrid/StagingMemoryPool.cs#L82). Essentially, when the pool is disposed (and the list of staging blocks is empty), calling ``Free`` results in a no-op.
- ``UpdateTexture`` no longer allocates an ``Action`` and a closure object. A staging block is used to pass the arguments to the execution thread. We could go even further and change ``OpenGLCommandExecutor.UpdateTexture`` to accept a reference to ``UpdateTextureArgs`` instead of separate parameters to avoid extra copying.
- I'm not really sure where to put ``UpdateTextureArgs``and whether it should be a nested struct.