### PR TITLE
Update cached position on move

### DIFF
--- a/src/Veldrid.SDL2/Sdl2Window.cs
+++ b/src/Veldrid.SDL2/Sdl2Window.cs
@@ -930,6 +930,7 @@ namespace Veldrid.Sdl2
         private void SetWindowPosition(int x, int y)
         {
             SDL_SetWindowPosition(_window, x, y);
+            _cachedPosition.Value = new Point(x, y);
         }
 
         private Point GetWindowSize()


### PR DESCRIPTION
_cachedPosition only gets updated via SDL_WindowEventID.Moved
if try to change both X and Y then second call to SetWindowPosition will use old cached value

Example
```c#
Sdl2Window _window;
_window.X = newX; // SetWindowPosition(newX, _cachedPosition.Value.Y)
_window.Y = newY; // SetWindowPosition(_cachedPosition.Value.X, newY) // BAD

```
Maybe and/or make Sdl2Window.SetWindowPosition public ?