### PR TITLE
OpenGL Context is now requested with ForwardCompatible Flag

### DIFF
--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -273,10 +273,10 @@ namespace Veldrid.StartupUtilities
 
         private static unsafe void SetSDLGLContextAttributes(GraphicsDeviceOptions options, GraphicsBackend backend)
         {
-            if (options.Debug)
-            {
-                Sdl2Native.SDL_GL_SetAttribute(SDL_GLAttribute.ContextFlags, (int)SDL_GLContextFlag.Debug);
-            }
+            SDL_GLContextFlag contextFlags = options.Debug ?    SDL_GLContextFlag.Debug | SDL_GLContextFlag.ForwardCompatible : 
+                                                                SDL_GLContextFlag.ForwardCompatible;
+
+            Sdl2Native.SDL_GL_SetAttribute(SDL_GLAttribute.ContextFlags, (int)contextFlags);
 
             (int major, int minor) = GetMaxGLVersion(backend == GraphicsBackend.OpenGLES);
 


### PR DESCRIPTION
Suggested change, please modify any way you see fit. Thank you

MESA drivers on Linux distros do not appear to return contexts higher than OpenGL 3.0 unless a Forward Compatible (no depreciated features) Core context is requested. The latest MESA drivers appear to sometimes not require this fix, but this improved behaviour appears unrealiabe under my limited testing.