### PR TITLE
[Vulkan] Avoid hidden enumerator allocations

### DIFF
--- a/src/Veldrid/Vk/VkSwapchainFramebuffer.cs
+++ b/src/Veldrid/Vk/VkSwapchainFramebuffer.cs
@@ -150,8 +150,9 @@ namespace Veldrid.Vk
 
         public override void TransitionToIntermediateLayout(VkCommandBuffer cb)
         {
-            foreach (FramebufferAttachment ca in ColorTargets)
+            for (int i = 0; i < ColorTargets.Count; i++)
             {
+                FramebufferAttachment ca = ColorTargets[i];
                 VkTexture vkTex = Util.AssertSubtype<Texture, VkTexture>(ca.Target);
                 vkTex.SetImageLayout(0, ca.ArrayLayer, VkImageLayout.ColorAttachmentOptimal);
             }
@@ -159,8 +160,9 @@ namespace Veldrid.Vk
 
         public override void TransitionToFinalLayout(VkCommandBuffer cb)
         {
-            foreach (FramebufferAttachment ca in ColorTargets)
+            for (int i = 0; i < ColorTargets.Count; i++)
             {
+                FramebufferAttachment ca = ColorTargets[i];
                 VkTexture vkTex = Util.AssertSubtype<Texture, VkTexture>(ca.Target);
                 vkTex.TransitionImageLayout(cb, 0, 1, ca.ArrayLayer, 1, VkImageLayout.PresentSrcKHR);
             }


### PR DESCRIPTION
Saw this when profiling allocations
![image](https://user-images.githubusercontent.com/6377116/42381072-b0dcce28-8138-11e8-820c-ee4f4935bb61.png)

![image](https://user-images.githubusercontent.com/6377116/42381160-ef1fa494-8138-11e8-8ae5-42584adc49db.png)
