### PR TITLE
Avoid allocations when calling GetHashCode or Equals on certain structs

### DIFF
--- a/src/Veldrid/BlendAttachmentDescription.cs
+++ b/src/Veldrid/BlendAttachmentDescription.cs
@@ -173,12 +173,12 @@ namespace Veldrid
         {
             return HashHelper.Combine(
                 BlendEnabled.GetHashCode(),
-                SourceColorFactor.GetHashCode(),
-                DestinationColorFactor.GetHashCode(),
-                ColorFunction.GetHashCode(),
-                SourceAlphaFactor.GetHashCode(),
-                DestinationAlphaFactor.GetHashCode(),
-                AlphaFunction.GetHashCode());
+                (int)SourceColorFactor,
+                (int)DestinationColorFactor,
+                (int)ColorFunction,
+                (int)SourceAlphaFactor,
+                (int)DestinationAlphaFactor,
+                (int)AlphaFunction);
         }
     }
 }

--- a/src/Veldrid/BufferDescription.cs
+++ b/src/Veldrid/BufferDescription.cs
@@ -94,7 +94,7 @@ namespace Veldrid
         {
             return HashHelper.Combine(
                 SizeInBytes.GetHashCode(),
-                Usage.GetHashCode(),
+                (int)Usage,
                 StructureByteStride.GetHashCode(),
                 RawBuffer.GetHashCode());
         }

--- a/src/Veldrid/DepthStencilStateDescription.cs
+++ b/src/Veldrid/DepthStencilStateDescription.cs
@@ -204,7 +204,7 @@ namespace Veldrid
             return HashHelper.Combine(
                 DepthTestEnabled.GetHashCode(),
                 DepthWriteEnabled.GetHashCode(),
-                DepthComparison.GetHashCode(),
+                (int)DepthComparison,
                 StencilTestEnabled.GetHashCode(),
                 StencilFront.GetHashCode(),
                 StencilBack.GetHashCode(),

--- a/src/Veldrid/FramebufferDescription.cs
+++ b/src/Veldrid/FramebufferDescription.cs
@@ -64,7 +64,7 @@ namespace Veldrid
         /// <returns>True if all elements and all array elements are equal; false otherswise.</returns>
         public bool Equals(FramebufferDescription other)
         {
-            return DepthTarget.Equals(other.DepthTarget) && Util.ArrayEqualsEquatable(ColorTargets, other.ColorTargets);
+            return Util.NullableEquals(DepthTarget, other.DepthTarget) && Util.ArrayEqualsEquatable(ColorTargets, other.ColorTargets);
         }
 
         /// <summary>

--- a/src/Veldrid/GraphicsPipelineDescription.cs
+++ b/src/Veldrid/GraphicsPipelineDescription.cs
@@ -160,7 +160,9 @@ namespace Veldrid
                 && PrimitiveTopology == other.PrimitiveTopology
                 && ShaderSet.Equals(other.ShaderSet)
                 && Util.ArrayEquals(ResourceLayouts, other.ResourceLayouts)
-                && ResourceBindingModel.Equals(other.ResourceBindingModel)
+                && (ResourceBindingModel.HasValue && other.ResourceBindingModel.HasValue
+                    ? ResourceBindingModel.Value == other.ResourceBindingModel.Value
+                    : ResourceBindingModel.HasValue == other.ResourceBindingModel.HasValue)
                 && Outputs.Equals(other.Outputs);
         }
 
@@ -174,7 +176,7 @@ namespace Veldrid
                 BlendState.GetHashCode(),
                 DepthStencilState.GetHashCode(),
                 RasterizerState.GetHashCode(),
-                PrimitiveTopology.GetHashCode(),
+                (int)PrimitiveTopology,
                 ShaderSet.GetHashCode(),
                 HashHelper.Array(ResourceLayouts),
                 ResourceBindingModel.GetHashCode(),

--- a/src/Veldrid/OutputAttachmentDescription.cs
+++ b/src/Veldrid/OutputAttachmentDescription.cs
@@ -37,7 +37,7 @@ namespace Veldrid
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
         public override int GetHashCode()
         {
-            return Format.GetHashCode();
+            return (int)Format;
         }
     }
 }

--- a/src/Veldrid/OutputsDescription.cs
+++ b/src/Veldrid/OutputsDescription.cs
@@ -89,7 +89,7 @@ namespace Veldrid
             return HashHelper.Combine(
                 DepthAttachment.GetHashCode(),
                 HashHelper.Array(ColorAttachments),
-                SampleCount.GetHashCode());
+                (int)SampleCount);
         }
     }
 }

--- a/src/Veldrid/RasterizerStateDescription.cs
+++ b/src/Veldrid/RasterizerStateDescription.cs
@@ -109,9 +109,9 @@ namespace Veldrid
         public override int GetHashCode()
         {
             return HashHelper.Combine(
-                CullMode.GetHashCode(),
-                FillMode.GetHashCode(),
-                FrontFace.GetHashCode(),
+                (int)CullMode,
+                (int)FillMode,
+                (int)FrontFace,
                 DepthClipEnabled.GetHashCode(),
                 ScissorTestEnabled.GetHashCode());
         }

--- a/src/Veldrid/ResourceLayoutElementDescription.cs
+++ b/src/Veldrid/ResourceLayoutElementDescription.cs
@@ -49,7 +49,7 @@ namespace Veldrid
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
         public override int GetHashCode()
         {
-            return HashHelper.Combine(Name.GetHashCode(), Kind.GetHashCode(), Stages.GetHashCode());
+            return HashHelper.Combine(Name.GetHashCode(), (int)Kind, (int)Stages);
         }
     }
 }

--- a/src/Veldrid/SamplerDescription.cs
+++ b/src/Veldrid/SamplerDescription.cs
@@ -186,16 +186,16 @@ namespace Veldrid
         public override int GetHashCode()
         {
             return HashHelper.Combine(
-                AddressModeU.GetHashCode(),
-                AddressModeV.GetHashCode(),
-                AddressModeW.GetHashCode(),
-                Filter.GetHashCode(),
+                (int)AddressModeU,
+                (int)AddressModeV,
+                (int)AddressModeW,
+                (int)Filter,
                 ComparisonKind.GetHashCode(),
                 MaximumAnisotropy.GetHashCode(),
                 MinimumLod.GetHashCode(),
                 MaximumLod.GetHashCode(),
                 LodBias.GetHashCode(),
-                BorderColor.GetHashCode());
+                (int)BorderColor);
         }
     }
 }

--- a/src/Veldrid/ShaderDescription.cs
+++ b/src/Veldrid/ShaderDescription.cs
@@ -83,7 +83,7 @@ namespace Veldrid
         public override int GetHashCode()
         {
             return HashHelper.Combine(
-                Stage.GetHashCode(),
+                (int)Stage,
                 ShaderBytes.GetHashCode(),
                 EntryPoint.GetHashCode(),
                 Debug.GetHashCode());

--- a/src/Veldrid/SpecializationConstant.cs
+++ b/src/Veldrid/SpecializationConstant.cs
@@ -106,7 +106,7 @@ namespace Veldrid
         /// <returns>True if all elements are equal; false otherswise.</returns>
         public bool Equals(SpecializationConstant other)
         {
-            return ID.Equals(other.ID) && Type.Equals(other.Type) && Data.Equals(other.Data);
+            return ID.Equals(other.ID) && Type == other.Type && Data.Equals(other.Data);
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace Veldrid
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
         public override int GetHashCode()
         {
-            return HashHelper.Combine(ID.GetHashCode(), Type.GetHashCode(), Data.GetHashCode());
+            return HashHelper.Combine(ID.GetHashCode(), (int)Type, Data.GetHashCode());
         }
     }
 }

--- a/src/Veldrid/StencilBehaviorDescription.cs
+++ b/src/Veldrid/StencilBehaviorDescription.cs
@@ -59,7 +59,7 @@ namespace Veldrid
         /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
         public override int GetHashCode()
         {
-            return HashHelper.Combine(Fail.GetHashCode(), Pass.GetHashCode(), DepthFail.GetHashCode(), Comparison.GetHashCode());
+            return HashHelper.Combine((int)Fail, (int)Pass, (int)DepthFail, (int)Comparison);
         }
     }
 }

--- a/src/Veldrid/TextureDescription.cs
+++ b/src/Veldrid/TextureDescription.cs
@@ -290,10 +290,10 @@ namespace Veldrid
                 Depth.GetHashCode(),
                 MipLevels.GetHashCode(),
                 ArrayLayers.GetHashCode(),
-                Format.GetHashCode(),
-                Usage.GetHashCode(),
-                Type.GetHashCode(),
-                SampleCount.GetHashCode());
+                (int)Format,
+                (int)Usage,
+                (int)Type,
+                (int)SampleCount);
         }
     }
 }

--- a/src/Veldrid/Util.cs
+++ b/src/Veldrid/Util.cs
@@ -57,6 +57,16 @@ namespace Veldrid
             return Encoding.UTF8.GetString(stringStart, characters);
         }
 
+        internal static bool NullableEquals<T>(T? left, T? right) where T : struct, IEquatable<T>
+        {
+            if (left.HasValue && right.HasValue)
+            {
+                return left.Value.Equals(right.Value);
+            }
+
+            return left.HasValue == right.HasValue;
+        }
+
         internal static bool ArrayEquals<T>(T[] left, T[] right) where T : class
         {
             if (left == null || right == null)

--- a/src/Veldrid/VertexElementDescription.cs
+++ b/src/Veldrid/VertexElementDescription.cs
@@ -67,8 +67,8 @@ namespace Veldrid
         {
             return HashHelper.Combine(
                 Name.GetHashCode(),
-                Format.GetHashCode(),
-                Semantic.GetHashCode());
+                (int)Format,
+                (int)Semantic);
         }
     }
 }


### PR DESCRIPTION
* Replace GetHashCode/Equals calls on enums with casts to int.
* Manually compare nullable values as Nullable does not implement ``IEquatable<T?>``. See ``Util.NullableEquals`` and ``GraphicsPipelineDescription.Equals``.
The BCL has ``Nullable.Equals<T>``, but it performs considerably worse than a custom implementation.