### PR TITLE
Update to ImageSharp beta5 and remove obsolete methods

### DIFF
--- a/src/NeoDemo/Objects/Skybox.cs
+++ b/src/NeoDemo/Objects/Skybox.cs
@@ -4,6 +4,7 @@ using SixLabors.ImageSharp.PixelFormats;
 using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Veldrid.Utilities;
 
 namespace Veldrid.NeoDemo.Objects
@@ -49,12 +50,12 @@ namespace Veldrid.NeoDemo.Objects
 
             Texture textureCube;
             TextureView textureView;
-            fixed (Rgba32* frontPin = &_front.DangerousGetPinnableReferenceToPixelBuffer())
-            fixed (Rgba32* backPin = &_back.DangerousGetPinnableReferenceToPixelBuffer())
-            fixed (Rgba32* leftPin = &_left.DangerousGetPinnableReferenceToPixelBuffer())
-            fixed (Rgba32* rightPin = &_right.DangerousGetPinnableReferenceToPixelBuffer())
-            fixed (Rgba32* topPin = &_top.DangerousGetPinnableReferenceToPixelBuffer())
-            fixed (Rgba32* bottomPin = &_bottom.DangerousGetPinnableReferenceToPixelBuffer())
+            fixed (Rgba32* frontPin = &MemoryMarshal.GetReference(_front.GetPixelSpan()))
+            fixed (Rgba32* backPin = &MemoryMarshal.GetReference(_back.GetPixelSpan()))
+            fixed (Rgba32* leftPin = &MemoryMarshal.GetReference(_left.GetPixelSpan()))
+            fixed (Rgba32* rightPin = &MemoryMarshal.GetReference(_right.GetPixelSpan()))
+            fixed (Rgba32* topPin = &MemoryMarshal.GetReference(_top.GetPixelSpan()))
+            fixed (Rgba32* bottomPin = &MemoryMarshal.GetReference(_bottom.GetPixelSpan()))
             {
                 uint width = (uint)_front.Width;
                 uint height = (uint)_front.Height;

--- a/src/Veldrid.ImageSharp/Veldrid.ImageSharp.csproj
+++ b/src/Veldrid.ImageSharp/Veldrid.ImageSharp.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Veldrid\Veldrid.csproj" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0004" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0005" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Simple stuff, just the update and some minor cleanup.