### PR TITLE
Add InitializeSDL to VeldridStartup

### DIFF
--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -9,6 +9,21 @@ namespace Veldrid.StartupUtilities
 {
     public static class VeldridStartup
     {
+        /// <summary>
+        /// Initialize SDL with SDLInitFlags.Video
+        /// <para>
+        /// If preferredBackend is OpenGL or OpenGLES sets the SDL contexts attributes appropriately
+        /// </para>
+        /// </summary>
+        public static void InitializeSDL(GraphicsDeviceOptions deviceOptions, GraphicsBackend preferredBackend)
+        {
+            Sdl2Native.SDL_Init(SDLInitFlags.Video);
+            if (preferredBackend == GraphicsBackend.OpenGL || preferredBackend == GraphicsBackend.OpenGLES)
+            {
+                SetSDLGLContextAttributes(deviceOptions, preferredBackend);
+            }
+        }
+        
         public static void CreateWindowAndGraphicsDevice(
             WindowCreateInfo windowCI,
             out Sdl2Window window,
@@ -34,11 +49,7 @@ namespace Veldrid.StartupUtilities
             out Sdl2Window window,
             out GraphicsDevice gd)
         {
-            Sdl2Native.SDL_Init(SDLInitFlags.Video);
-            if (preferredBackend == GraphicsBackend.OpenGL || preferredBackend == GraphicsBackend.OpenGLES)
-            {
-                SetSDLGLContextAttributes(deviceOptions, preferredBackend);
-            }
+            InitializeSDL(deviceOptions, preferredBackend);
 
             window = CreateWindow(ref windowCI);
             gd = CreateGraphicsDevice(window, deviceOptions, preferredBackend);


### PR DESCRIPTION
I wanted to be able to initialize SDLs context attributes the same way it's done in VeldridStartup currently but it was private.

Figured I would extract and expose a method that allows me to initialize SDL in one call while leveraging the other work that exists in VeldridStartup