### PR TITLE
Allow non-multiple-of-four-sized texture to be updated with multiple-of-four mipmap data

### DIFF
--- a/src/Veldrid.Tests/TextureTests.cs
+++ b/src/Veldrid.Tests/TextureTests.cs
@@ -630,6 +630,24 @@ namespace Veldrid.Tests
         }
 
         [Fact]
+        public unsafe void Update_NonMultipleOfFourWithCompressedTexture_2D()
+        {
+            Texture tex2D = RF.CreateTexture(TextureDescription.Texture2D(
+                2, 2, 1, 1, PixelFormat.BC1_Rgb_UNorm, TextureUsage.Staging));
+
+            byte[] data = new byte[16];
+
+            fixed (byte* dataPtr = &data[0])
+            {
+                GD.UpdateTexture(
+                    tex2D, (IntPtr)dataPtr, (uint)data.Length,
+                    0, 0, 0,
+                    4, 4, 1,
+                    0, 0);
+            }
+        }
+
+        [Fact]
         public unsafe void Map_NonZeroMip_3D()
         {
             Texture tex3D = RF.CreateTexture(TextureDescription.Texture3D(

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -473,7 +473,21 @@ namespace Veldrid
                     $"The data size is less than expected for the given update region. At least {expectedSize} bytes must be provided, but only {sizeInBytes} were.");
             }
 
-            if (x + width > texture.Width || y + height > texture.Height || z + depth > texture.Depth)
+            // Compressed textures don't necessarily need to have a Texture.Width and Texture.Height that are a multiple of 4.
+            // But the mipdata width and height *does* need to be a multiple of 4.
+            uint roundedTextureWidth, roundedTextureHeight;
+            if (FormatHelpers.IsCompressedFormat(texture.Format))
+            {
+                roundedTextureWidth = (texture.Width + 3) / 4 * 4;
+                roundedTextureHeight = (texture.Height + 3) / 4 * 4;
+            }
+            else
+            {
+                roundedTextureWidth = texture.Width;
+                roundedTextureHeight = texture.Height;
+            }
+
+            if (x + width > roundedTextureWidth || y + height > roundedTextureHeight || z + depth > texture.Depth)
             {
                 throw new VeldridException($"The given region does not fit into the Texture.");
             }


### PR DESCRIPTION
I found this bug because one SAGE texture is BC1-compressed, but sized 2 x 512. The mipmap data still needs to be multiple-of-four-sized, but this isn't currently allowed by Veldrid.