### PR TITLE
Fix D3D11 TextureView creation for arrayLayer > 0

### DIFF
--- a/src/Veldrid/D3D11/D3D11TextureView.cs
+++ b/src/Veldrid/D3D11/D3D11TextureView.cs
@@ -17,7 +17,7 @@ namespace Veldrid.D3D11
             D3D11Texture d3dTex = Util.AssertSubtype<Texture, D3D11Texture>(description.Target);
 
             if (BaseMipLevel == 0 && MipLevels == Target.MipLevels
-                || BaseArrayLayer == 0 && ArrayLayers == Target.ArrayLayers)
+                && BaseArrayLayer == 0 && ArrayLayers == Target.ArrayLayers)
             {
                 ShaderResourceView = d3dTex.GetFullShaderResourceView();
             }


### PR DESCRIPTION
I assume this was a typo - at the moment, it's impossible to create a `TextureView` for anything other than the first array layer in a `Texture2D`  (assuming it has `ArrayLayers > 1`, and assuming you want all mip levels in the texture view).