### PR TITLE
Fix build failure on Ubuntu 18.04

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <NerdbankGitVersioningVersion>2.2.33</NerdbankGitVersioningVersion>
+    <NerdbankGitVersioningVersion>2.3.38</NerdbankGitVersioningVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #119 without needing to install `libcurl3` on Ubuntu 18.04 (and presumably newer).