### PR TITLE
[D3D11, Vulkan] Handle 1D textures correctly when creating a TextureView

### DIFF
--- a/src/Veldrid/D3D11/D3D11TextureView.cs
+++ b/src/Veldrid/D3D11/D3D11TextureView.cs
@@ -37,15 +37,33 @@ namespace Veldrid.D3D11
                 {
                     if (d3dTex.ArrayLayers == 1)
                     {
-                        uavDesc.Dimension = UnorderedAccessViewDimension.Texture2D;
-                        uavDesc.Texture2D.MipSlice = (int)description.BaseMipLevel;
+                        if (d3dTex.Type == TextureType.Texture1D)
+                        {
+                            uavDesc.Dimension = UnorderedAccessViewDimension.Texture1D;
+                            uavDesc.Texture1D.MipSlice = (int)description.BaseMipLevel;
+                        }
+                        else
+                        {
+                            uavDesc.Dimension = UnorderedAccessViewDimension.Texture2D;
+                            uavDesc.Texture2D.MipSlice = (int)description.BaseMipLevel;
+                        }
                     }
                     else
                     {
-                        uavDesc.Dimension = UnorderedAccessViewDimension.Texture2DArray;
-                        uavDesc.Texture2DArray.MipSlice = (int)description.BaseMipLevel;
-                        uavDesc.Texture2DArray.FirstArraySlice = (int)description.BaseArrayLayer;
-                        uavDesc.Texture2DArray.ArraySize = (int)description.ArrayLayers;
+                        if (d3dTex.Type == TextureType.Texture1D)
+                        {
+                            uavDesc.Dimension = UnorderedAccessViewDimension.Texture1DArray;
+                            uavDesc.Texture1DArray.MipSlice = (int)description.BaseMipLevel;
+                            uavDesc.Texture1DArray.FirstArraySlice = (int)description.BaseArrayLayer;
+                            uavDesc.Texture1DArray.ArraySize = (int)description.ArrayLayers;
+                        }
+                        else
+                        {
+                            uavDesc.Dimension = UnorderedAccessViewDimension.Texture2DArray;
+                            uavDesc.Texture2DArray.MipSlice = (int)description.BaseMipLevel;
+                            uavDesc.Texture2DArray.FirstArraySlice = (int)description.BaseArrayLayer;
+                            uavDesc.Texture2DArray.ArraySize = (int)description.ArrayLayers;
+                        }
                     }
                 }
                 else

--- a/src/Veldrid/D3D11/D3D11Util.cs
+++ b/src/Veldrid/D3D11/D3D11Util.cs
@@ -42,17 +42,37 @@ namespace Veldrid.D3D11
             {
                 if (tex.ArrayLayers == 1)
                 {
-                    srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Texture2D;
-                    srvDesc.Texture2D.MostDetailedMip = (int)baseMipLevel;
-                    srvDesc.Texture2D.MipLevels = (int)levelCount;
+                    if (tex.Type == TextureType.Texture1D)
+                    {
+                        srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Texture1D;
+                        srvDesc.Texture1D.MostDetailedMip = (int)baseMipLevel;
+                        srvDesc.Texture1D.MipLevels = (int)levelCount;
+                    }
+                    else
+                    {
+                        srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Texture2D;
+                        srvDesc.Texture2D.MostDetailedMip = (int)baseMipLevel;
+                        srvDesc.Texture2D.MipLevels = (int)levelCount;
+                    }
                 }
                 else
                 {
-                    srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Texture2DArray;
-                    srvDesc.Texture2DArray.MostDetailedMip = (int)baseMipLevel;
-                    srvDesc.Texture2DArray.MipLevels = (int)levelCount;
-                    srvDesc.Texture2DArray.FirstArraySlice = (int)baseArrayLayer;
-                    srvDesc.Texture2DArray.ArraySize = (int)layerCount;
+                    if (tex.Type == TextureType.Texture1D)
+                    {
+                        srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Texture1DArray;
+                        srvDesc.Texture1DArray.MostDetailedMip = (int)baseMipLevel;
+                        srvDesc.Texture1DArray.MipLevels = (int)levelCount;
+                        srvDesc.Texture1DArray.FirstArraySlice = (int)baseArrayLayer;
+                        srvDesc.Texture1DArray.ArraySize = (int)layerCount;
+                    }
+                    else
+                    {
+                        srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Texture2DArray;
+                        srvDesc.Texture2DArray.MostDetailedMip = (int)baseMipLevel;
+                        srvDesc.Texture2DArray.MipLevels = (int)levelCount;
+                        srvDesc.Texture2DArray.FirstArraySlice = (int)baseArrayLayer;
+                        srvDesc.Texture2DArray.ArraySize = (int)layerCount;
+                    }
                 }
             }
             else

--- a/src/Veldrid/Vk/VkTextureView.cs
+++ b/src/Veldrid/Vk/VkTextureView.cs
@@ -46,13 +46,22 @@ namespace Veldrid.Vk
                 imageViewCI.viewType = description.ArrayLayers == 1 ? VkImageViewType.ImageCube : VkImageViewType.ImageCubeArray;
                 imageViewCI.subresourceRange.layerCount *= 6;
             }
-            else if (tex.Depth == 1)
+
+            switch (tex.Type)
             {
-                imageViewCI.viewType = description.ArrayLayers == 1 ? VkImageViewType.Image2D : VkImageViewType.Image2DArray;
-            }
-            else
-            {
-                imageViewCI.viewType = VkImageViewType.Image3D;
+                case TextureType.Texture1D:
+                    imageViewCI.viewType = description.ArrayLayers == 1
+                        ? VkImageViewType.Image1D
+                        : VkImageViewType.Image1DArray;
+                    break;
+                case TextureType.Texture2D:
+                    imageViewCI.viewType = description.ArrayLayers == 1
+                        ? VkImageViewType.Image2D
+                        : VkImageViewType.Image2DArray;
+                    break;
+                case TextureType.Texture3D:
+                    imageViewCI.viewType = VkImageViewType.Image3D;
+                    break;
             }
 
             vkCreateImageView(_gd.Device, ref imageViewCI, null, out _imageView);


### PR DESCRIPTION
The current code does not account for the existence of 1D textures.
- The Metal backend seems to handle this case correctly, though I can't verify that
- ~~OpenGL doesn't actually have TextureViews, so no changes are required~~
Wrong. There is in fact a code path that uses glTextureView, but it isn't taken when creating a full TextureView, which is why I'm not experiencing any issues. Changes might be required.
- D3D11 and Vulkan are covered by this PR

Maybe we should add some tests, though I'm not sure if it's possible to verify anything other than the fact that creating a TextureView succeeds for 1D textures. 