### PR TITLE
[OpenGL] Set scissor rect relative to framebuffer, not viewport.

### DIFF
--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -983,7 +983,7 @@ namespace Veldrid.OpenGL
                 glScissorIndexed(
                     index,
                     (int)x,
-                    (int)(_viewports[(int)index].Height - (int)height - y),
+                    (int)(_fb.Height - (int)height - y),
                     width,
                     height);
                 CheckLastError();
@@ -994,7 +994,7 @@ namespace Veldrid.OpenGL
                 {
                     glScissor(
                         (int)x,
-                        (int)(_viewports[(int)index].Height - (int)height - y),
+                        (int)(_fb.Height - (int)height - y),
                         width,
                         height);
                     CheckLastError();


### PR DESCRIPTION
This fixes the misalignment of scissor rects when the viewport is not a full view of the framebuffer.