### PR TITLE
Convert NeoDemo FullScreenQuad shader to HLSL

### DIFF
--- a/src/NeoDemo/Assets/Shaders/FullScreenQuad.hlsl.frag
+++ b/src/NeoDemo/Assets/Shaders/FullScreenQuad.hlsl.frag
@@ -1,0 +1,35 @@
+
+struct FragmentIn
+{
+    float4 Position : SV_Position;
+    float2 TexCoords : TEXCOORD0;
+};
+
+[[vk::binding(0)]]
+Texture2D SourceTexture;
+[[vk::binding(1)]]
+SamplerState SourceSampler;
+
+const bool OutputFormatSrgb = true;
+
+float3 LinearToSrgb(float3 linearColor)
+{
+    // http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
+    float3 S1 = sqrt(linearColor);
+    float3 S2 = sqrt(S1);
+    float3 S3 = sqrt(S2);
+    float3 sRGB = 0.662002687 * S1 + 0.684122060 * S2 - 0.323583601 * S3 - 0.0225411470 * linearColor;
+    return sRGB;
+}
+
+float4 main(FragmentIn input) : SV_Target0
+{
+    float4 color = SourceTexture.Sample(SourceSampler, input.TexCoords);
+
+    if (!OutputFormatSrgb)
+    {
+        color = float4(LinearToSrgb(color.rgb), 1);
+    }
+
+    return color;
+}

--- a/src/NeoDemo/Assets/Shaders/FullScreenQuad.hlsl.vert
+++ b/src/NeoDemo/Assets/Shaders/FullScreenQuad.hlsl.vert
@@ -1,0 +1,20 @@
+
+struct VertexIn
+{
+    float2 Position : POSITION0;
+    float2 TexCoords : TEXCOORD0;
+};
+
+struct FragmentIn
+{
+    float4 Position : SV_Position;
+    float2 TexCoords : TEXCOORD0;
+};
+
+FragmentIn main(VertexIn input)
+{
+    FragmentIn output;
+    output.TexCoords = input.TexCoords;
+    output.Position = float4(input.Position.x, input.Position.y, 0, 1);
+    return output;
+}

--- a/src/NeoDemo/Assets/Shaders/compile.ps1
+++ b/src/NeoDemo/Assets/Shaders/compile.ps1
@@ -2,7 +2,12 @@ $fileNames = Get-ChildItem -Path $scriptPath -Recurse
 
 foreach ($file in $fileNames)
 {
-    if ($file.Name.EndsWith("vert") -Or $file.Name.EndsWith("frag") -Or $file.Name.EndsWith("comp"))
+    if ($file.Name.EndsWith("hlsl.vert") -Or $file.Name.EndsWith("hlsl.frag"))
+    {
+        Write-Host "Compiling $file"
+        glslangvalidator -e main -V -D $file -o $file".spv"
+    }
+    elseif ($file.Name.EndsWith("vert") -Or $file.Name.EndsWith("frag") -Or $file.Name.EndsWith("comp"))
     {
         Write-Host "Compiling $file"
         glslangvalidator -V $file -o $file".spv"

--- a/src/NeoDemo/Objects/FullScreenQuad.cs
+++ b/src/NeoDemo/Objects/FullScreenQuad.cs
@@ -21,7 +21,7 @@ namespace Veldrid.NeoDemo.Objects
                 new ResourceLayoutElementDescription("SourceTexture", ResourceKind.TextureReadOnly, ShaderStages.Fragment),
                 new ResourceLayoutElementDescription("SourceSampler", ResourceKind.Sampler, ShaderStages.Fragment)));
 
-            (Shader vs, Shader fs) = StaticResourceCache.GetShaders(gd, gd.ResourceFactory, "FullScreenQuad");
+            (Shader vs, Shader fs) = StaticResourceCache.GetShaders(gd, gd.ResourceFactory, "FullScreenQuad.hlsl");
 
             GraphicsPipelineDescription pd = new GraphicsPipelineDescription(
                 new BlendStateDescription(


### PR DESCRIPTION
This is a companion to mellinoe/veldrid-spirv#2 (Add HLSL compilation support).