### PR TITLE
Fix SamplerAddressMode.Clamp mapping in OpenGL

### DIFF
--- a/src/Veldrid/OpenGL/OpenGLFormats.cs
+++ b/src/Veldrid/OpenGL/OpenGLFormats.cs
@@ -193,7 +193,7 @@ namespace Veldrid.OpenGL
                 case SamplerAddressMode.Mirror:
                     return TextureWrapMode.MirroredRepeat;
                 case SamplerAddressMode.Clamp:
-                    return TextureWrapMode.Clamp;
+                    return TextureWrapMode.ClampToEdge;
                 case SamplerAddressMode.Border:
                     return TextureWrapMode.ClampToBorder;
                 default:


### PR DESCRIPTION
The previous mapping to Clamp caused a glError of INVALID_ENUM on OSX, but ClampToEdge is supported.