### PR TITLE
Fix mirror sampler address mode on metal

### DIFF
--- a/src/Veldrid/MTL/MTLFormats.cs
+++ b/src/Veldrid/MTL/MTLFormats.cs
@@ -433,7 +433,7 @@ namespace Veldrid.MTL
                 case SamplerAddressMode.Clamp:
                     return MTLSamplerAddressMode.ClampToEdge;
                 case SamplerAddressMode.Mirror:
-                    return MTLSamplerAddressMode.MirrorClampToEdge;
+                    return MTLSamplerAddressMode.MirrorRepeat;
                 case SamplerAddressMode.Wrap:
                     return MTLSamplerAddressMode.Repeat;
                 default:


### PR DESCRIPTION
Mapping Mirror to MirrorRepeat instead of MirrorClampToEdge to be consistent with the other backends (at the very least OpenGL backend which I tested it looks identical, but looking at the code I think the other backends as well).