### PR TITLE
Create IWindow for StartupUtilities

### DIFF
--- a/src/Veldrid.SDL2/IWindow.cs
+++ b/src/Veldrid.SDL2/IWindow.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Veldrid.Sdl2
+{
+    public interface IWindow
+    {
+        int Width { get; }
+        int Height { get; }
+
+        IntPtr SdlWindowHandle { get; }
+    }
+}

--- a/src/Veldrid.SDL2/Sdl2Window.cs
+++ b/src/Veldrid.SDL2/Sdl2Window.cs
@@ -13,7 +13,7 @@ using Veldrid;
 
 namespace Veldrid.Sdl2
 {
-    public unsafe class Sdl2Window
+    public unsafe class Sdl2Window : IWindow
     {
         private readonly List<SDL_Event> _events = new List<SDL_Event>();
         private IntPtr _window;

--- a/src/Veldrid.SDL2/Veldrid.SDL2.csproj
+++ b/src/Veldrid.SDL2/Veldrid.SDL2.csproj
@@ -38,6 +38,7 @@
   <PropertyGroup>
     <Description>Raw SDL2 bindings for .NET. Used by Veldrid for window and input management.</Description>
     <PackageTags>Core Standard Game SDL2 Window Input</PackageTags>
+    <RootNamespace>Veldrid.Sdl2</RootNamespace>
   </PropertyGroup>
 
 </Project>

--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -11,7 +11,7 @@ namespace Veldrid.StartupUtilities
     {
         public static void CreateWindowAndGraphicsDevice(
             WindowCreateInfo windowCI,
-            out Sdl2Window window,
+            out IWindow window,
             out GraphicsDevice gd)
             => CreateWindowAndGraphicsDevice(
                 windowCI,
@@ -23,7 +23,7 @@ namespace Veldrid.StartupUtilities
         public static void CreateWindowAndGraphicsDevice(
             WindowCreateInfo windowCI,
             GraphicsDeviceOptions deviceOptions,
-            out Sdl2Window window,
+            out IWindow window,
             out GraphicsDevice gd)
             => CreateWindowAndGraphicsDevice(windowCI, deviceOptions, GetPlatformDefaultBackend(), out window, out gd);
 
@@ -31,7 +31,7 @@ namespace Veldrid.StartupUtilities
             WindowCreateInfo windowCI,
             GraphicsDeviceOptions deviceOptions,
             GraphicsBackend preferredBackend,
-            out Sdl2Window window,
+            out IWindow window,
             out GraphicsDevice gd)
         {
             Sdl2Native.SDL_Init(SDLInitFlags.Video);
@@ -88,14 +88,14 @@ namespace Veldrid.StartupUtilities
             }
         }
 
-        public static GraphicsDevice CreateGraphicsDevice(Sdl2Window window)
+        public static GraphicsDevice CreateGraphicsDevice(IWindow window)
             => CreateGraphicsDevice(window, new GraphicsDeviceOptions(), GetPlatformDefaultBackend());
-        public static GraphicsDevice CreateGraphicsDevice(Sdl2Window window, GraphicsDeviceOptions options)
+        public static GraphicsDevice CreateGraphicsDevice(IWindow window, GraphicsDeviceOptions options)
             => CreateGraphicsDevice(window, options, GetPlatformDefaultBackend());
-        public static GraphicsDevice CreateGraphicsDevice(Sdl2Window window, GraphicsBackend preferredBackend)
+        public static GraphicsDevice CreateGraphicsDevice(IWindow window, GraphicsBackend preferredBackend)
             => CreateGraphicsDevice(window, new GraphicsDeviceOptions(), preferredBackend);
         public static GraphicsDevice CreateGraphicsDevice(
-            Sdl2Window window,
+            IWindow window,
             GraphicsDeviceOptions options,
             GraphicsBackend preferredBackend)
         {
@@ -136,7 +136,7 @@ namespace Veldrid.StartupUtilities
             }
         }
 
-        public static unsafe SwapchainSource GetSwapchainSource(Sdl2Window window)
+        public static unsafe SwapchainSource GetSwapchainSource(IWindow window)
         {
             IntPtr sdlHandle = window.SdlWindowHandle;
             SDL_SysWMinfo sysWmInfo;
@@ -165,11 +165,11 @@ namespace Veldrid.StartupUtilities
         }
 
 #if !EXCLUDE_METAL_BACKEND
-        private static unsafe GraphicsDevice CreateMetalGraphicsDevice(GraphicsDeviceOptions options, Sdl2Window window)
+        private static unsafe GraphicsDevice CreateMetalGraphicsDevice(GraphicsDeviceOptions options, IWindow window)
             => CreateMetalGraphicsDevice(options, window, false);
         private static unsafe GraphicsDevice CreateMetalGraphicsDevice(
             GraphicsDeviceOptions options,
-            Sdl2Window window,
+            IWindow window,
             bool colorSrgb)
         {
             SwapchainSource source = GetSwapchainSource(window);
@@ -205,11 +205,11 @@ namespace Veldrid.StartupUtilities
         }
 
 #if !EXCLUDE_VULKAN_BACKEND
-        public static unsafe GraphicsDevice CreateVulkanGraphicsDevice(GraphicsDeviceOptions options, Sdl2Window window)
+        public static unsafe GraphicsDevice CreateVulkanGraphicsDevice(GraphicsDeviceOptions options, IWindow window)
             => CreateVulkanGraphicsDevice(options, window, false);
         public static unsafe GraphicsDevice CreateVulkanGraphicsDevice(
             GraphicsDeviceOptions options,
-            Sdl2Window window,
+            IWindow window,
             bool colorSrgb)
         {
             SwapchainDescription scDesc = new SwapchainDescription(
@@ -245,7 +245,7 @@ namespace Veldrid.StartupUtilities
 #if !EXCLUDE_OPENGL_BACKEND
         public static unsafe GraphicsDevice CreateDefaultOpenGLGraphicsDevice(
             GraphicsDeviceOptions options,
-            Sdl2Window window,
+            IWindow window,
             GraphicsBackend backend)
         {
             Sdl2Native.SDL_ClearError();
@@ -364,7 +364,7 @@ namespace Veldrid.StartupUtilities
 #if !EXCLUDE_D3D11_BACKEND
         public static GraphicsDevice CreateDefaultD3D11GraphicsDevice(
             GraphicsDeviceOptions options,
-            Sdl2Window window)
+            IWindow window)
         {
             SwapchainSource source = GetSwapchainSource(window);
             SwapchainDescription swapchainDesc = new SwapchainDescription(


### PR DESCRIPTION
Let's depend less on `Sdl2Window` inside the utilities methods.