### PR TITLE
Fix off-by-one issue in Veldrid.Rectangle

### DIFF
--- a/src/Veldrid.SDL2/Rectangle.cs
+++ b/src/Veldrid.SDL2/Rectangle.cs
@@ -36,8 +36,8 @@ namespace Veldrid
         public bool Contains(Point p) => Contains(p.X, p.Y);
         public bool Contains(int x, int y)
         {
-            return (X <= x && (X + Width) >= x)
-                && (Y <= y && (Y + Height) >= y);
+            return (X <= x && (X + Width) > x)
+                && (Y <= y && (Y + Height) > y);
         }
 
         public bool Equals(Rectangle other) => X.Equals(other.X) && Y.Equals(other.Y) && Width.Equals(other.Width) && Height.Equals(other.Height);


### PR DESCRIPTION
Was doing some stuff with the Rectangle class defined in Veldrid.SDL2 and noticed it seems to have an off-by-one error. Compared against the behaviour of System.Drawing.Rectangle to verify.