### PR TITLE
Add "position" and "size" Vector2 convenience properties to Veldrid.Rectangle.

### DIFF
--- a/src/Veldrid.SDL2/Rectangle.cs
+++ b/src/Veldrid.SDL2/Rectangle.cs
@@ -33,6 +33,9 @@ namespace Veldrid
         public int Top => Y;
         public int Bottom => Y + Height;
 
+        public Vector2 Position => new Vector2(X, Y);
+        public Vector2 Size => new Vector2(Width, Height);
+
         public bool Contains(Point p) => Contains(p.X, p.Y);
         public bool Contains(int x, int y)
         {


### PR DESCRIPTION
Noticed that I was writing a lot of code like "new Vector2(rect.Width, rect.Height)" and "new Vector2(rect.X, rect.Y)" when working with rectangles, so thought it would be a good idea to add some properties to simplify things.