### PR TITLE
Add OpenGL resource name validation to debug builds

### DIFF
--- a/src/Veldrid.OpenGLBindings/OpenGLNative.cs
+++ b/src/Veldrid.OpenGLBindings/OpenGLNative.cs
@@ -1480,6 +1480,40 @@ namespace Veldrid.OpenGLBinding
             int* @params) => p_glGetActiveUniformBlockiv(program, uniformBlockIndex, pname, @params);
 
         [UnmanagedFunctionPointer(CallConv)]
+        private delegate void glGetActiveUniformBlockName_t(
+            uint program,
+            uint uniformBlockIndex,
+            uint bufSize,
+            uint* length,
+            byte* uniformBlockName);
+        private static glGetActiveUniformBlockName_t p_glGetActiveUniformBlockName;
+        public static void glGetActiveUniformBlockName(
+            uint program,
+            uint uniformBlockIndex,
+            uint bufSize,
+            uint* length,
+            byte* uniformBlockName) => p_glGetActiveUniformBlockName(program, uniformBlockIndex, bufSize, length, uniformBlockName);
+
+        [UnmanagedFunctionPointer(CallConv)]
+        private delegate void glGetActiveUniform_t(
+            uint program,
+            uint index,
+            uint bufSize,
+            uint* length,
+            int* size,
+            uint* type,
+            byte* name);
+        private static glGetActiveUniform_t p_glGetActiveUniform;
+        public static void glGetActiveUniform(
+            uint program,
+            uint index,
+            uint bufSize,
+            uint* length,
+            int* size,
+            uint* type,
+            byte* name) => p_glGetActiveUniform(program, index, bufSize, length, size, type, name);
+
+        [UnmanagedFunctionPointer(CallConv)]
         private delegate void glGetCompressedTexImage_t(TextureTarget target, int level, void* pixels);
         private static glGetCompressedTexImage_t p_glGetCompressedTexImage;
         public static void glGetCompressedTexImage(TextureTarget target, int level, void* pixels)
@@ -1674,6 +1708,8 @@ namespace Veldrid.OpenGLBinding
             LoadFunction("glStencilMask", out p_glStencilMask);
             LoadFunction("glClearStencil", out p_glClearStencil);
             LoadFunction("glGetActiveUniformBlockiv", out p_glGetActiveUniformBlockiv);
+            LoadFunction("glGetActiveUniformBlockName", out p_glGetActiveUniformBlockName);
+            LoadFunction("glGetActiveUniform", out p_glGetActiveUniform);
             LoadFunction("glGetCompressedTexImage", out p_glGetCompressedTexImage);
             LoadFunction("glGetCompressedTextureImage", out p_glGetCompressedTextureImage);
             LoadFunction("glGetTexLevelParameteriv", out p_glGetTexLevelParameteriv);

--- a/src/Veldrid.SDL2/Rectangle.cs
+++ b/src/Veldrid.SDL2/Rectangle.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Numerics;
 
 namespace Veldrid
 {

--- a/src/Veldrid.SDL2/Rectangle.cs
+++ b/src/Veldrid.SDL2/Rectangle.cs
@@ -36,8 +36,8 @@ namespace Veldrid
         public bool Contains(Point p) => Contains(p.X, p.Y);
         public bool Contains(int x, int y)
         {
-            return (X <= x && (X + Width) >= x)
-                && (Y <= y && (Y + Height) >= y);
+            return (X <= x && (X + Width) > x)
+                && (Y <= y && (Y + Height) > y);
         }
 
         public bool Equals(Rectangle other) => X.Equals(other.X) && Y.Equals(other.Y) && Width.Equals(other.Width) && Height.Equals(other.Height);

--- a/src/Veldrid.SDL2/Rectangle.cs
+++ b/src/Veldrid.SDL2/Rectangle.cs
@@ -33,6 +33,9 @@ namespace Veldrid
         public int Top => Y;
         public int Bottom => Y + Height;
 
+        public Vector2 Position => new Vector2(X, Y);
+        public Vector2 Size => new Vector2(Width, Height);
+
         public bool Contains(Point p) => Contains(p.X, p.Y);
         public bool Contains(int x, int y)
         {

--- a/src/Veldrid/OpenGL/OpenGLPipeline.cs
+++ b/src/Veldrid/OpenGL/OpenGLPipeline.cs
@@ -233,15 +233,18 @@ namespace Veldrid.OpenGL
                             uint bufferNameByteCount = 64;
                             byte* bufferNamePtr = stackalloc byte[(int)bufferNameByteCount];
                             var names = new List<string>();
-                            do
+                            while (true)
                             {
                                 uint actualLength;
-                                glGetActiveUniformBlockName(_program, uniformBufferIndex, bufferNameByteCount,
-                                    &actualLength, bufferNamePtr);
+                                glGetActiveUniformBlockName(_program, uniformBufferIndex, bufferNameByteCount, &actualLength, bufferNamePtr);
+
+                                if (glGetError() != 0)
+                                    break;
+
                                 string name = Encoding.UTF8.GetString(bufferNamePtr, (int)actualLength);
                                 names.Add(name);
                                 uniformBufferIndex++;
-                            } while (glGetError() == 0);
+                            }
 
                             throw new VeldridException($"Unable to bind uniform buffer \"{resourceName}\" by name. Valid names for this pipeline are: {string.Join(", ", names.Distinct())}");
                         }
@@ -335,6 +338,7 @@ namespace Veldrid.OpenGL
             }
         }
 
+#if DEBUG && GL_VALIDATE_SHADER_RESOURCE_NAMES
         void ReportInvalidResourceName(string resourceName)
         {
             uint uniformIndex = 0;
@@ -342,7 +346,7 @@ namespace Veldrid.OpenGL
             byte* resourceNamePtr = stackalloc byte[(int)resourceNameByteCount];
 
             var names = new List<string>();
-            do
+            while (true)
             {
                 uint actualLength;
                 int size;
@@ -350,13 +354,17 @@ namespace Veldrid.OpenGL
                 glGetActiveUniform(_program, uniformIndex, resourceNameByteCount,
                     &actualLength, &size, &type, resourceNamePtr);
 
+                if (glGetError() != 0)
+                    break;
+
                 string name = Encoding.UTF8.GetString(resourceNamePtr, (int)actualLength);
                 names.Add(name);
                 uniformIndex++;
-            } while (glGetError() == 0);
+            }
 
             throw new VeldridException($"Unable to bind uniform \"{resourceName}\" by name. Valid names for this pipeline are: {string.Join(", ", names.Distinct())}");
         }
+#endif
 
         private void CreateComputeGLResources()
         {

--- a/src/Veldrid/OpenGL/OpenGLPipeline.cs
+++ b/src/Veldrid/OpenGL/OpenGLPipeline.cs
@@ -225,6 +225,26 @@ namespace Veldrid.OpenGL
                             CheckLastError();
                             uniformBindings[i] = new OpenGLUniformBinding(_program, blockIndex, (uint)blockSize);
                         }
+#if DEBUG
+                        else
+                        {
+                            uint uniformBufferIndex = 0;
+                            var names = new List<string>();
+                            do
+                            {
+                                uint bufferNameByteCount = 64;
+                                byte* bufferNamePtr = stackalloc byte[(int) bufferNameByteCount];
+                                uint actualLength;
+                                glGetActiveUniformBlockName(_program, uniformBufferIndex, bufferNameByteCount,
+                                    &actualLength, bufferNamePtr);
+                                string name = Encoding.UTF8.GetString(bufferNamePtr, (int) actualLength);
+                                names.Add(name);
+                                uniformBufferIndex++;
+                            } while (glGetError() == 0);
+
+                            throw new InvalidOperationException($"Unable to bind uniform buffer \"{resourceName}\" by name. Valid names for this pipeline are: {string.Join(", ", names)}");
+                        }
+#endif
                     }
                     else if (resource.Kind == ResourceKind.TextureReadOnly)
                     {
@@ -239,6 +259,27 @@ namespace Veldrid.OpenGL
                         resourceNamePtr[byteCount - 1] = 0; // Add null terminator.
                         int location = glGetUniformLocation(_program, resourceNamePtr);
                         CheckLastError();
+#if DEBUG
+                        if (location == -1)
+                        {
+                            uint uniformIndex = 0;
+                            var names = new List<string>();
+                            do
+                            {
+                                uint bufferNameByteCount = 64;
+                                byte* bufferNamePtr = stackalloc byte[(int) bufferNameByteCount];
+                                uint actualLength;
+                                int size;
+                                uint type;
+                                glGetActiveUniform(_program, uniformIndex, bufferNameByteCount,
+                                    &actualLength, &size, &type, bufferNamePtr);
+                                string name = Encoding.UTF8.GetString(bufferNamePtr, (int) actualLength);
+                                names.Add(name);
+                                uniformIndex++;
+                            } while (glGetError() == 0);
+                            throw new InvalidOperationException($"Unable to bind uniform texture \"{resourceName}\" by name. Valid names for this pipeline are: {string.Join(", ", names)}");
+                        }
+#endif
                         relativeTextureIndex += 1;
                         textureBindings[i] = new OpenGLTextureBindingSlotInfo() { RelativeIndex = relativeTextureIndex, UniformLocation = location };
                         lastTextureLocation = location;
@@ -257,6 +298,28 @@ namespace Veldrid.OpenGL
                         resourceNamePtr[byteCount - 1] = 0; // Add null terminator.
                         int location = glGetUniformLocation(_program, resourceNamePtr);
                         CheckLastError();
+#if DEBUG
+                        if (location == -1)
+                        {
+                            uint uniformIndex = 0;
+                            var names = new List<string>();
+                            do
+                            {
+                                uint bufferNameByteCount = 64;
+                                byte* bufferNamePtr = stackalloc byte[(int) bufferNameByteCount];
+                                uint actualLength;
+                                int size;
+                                uint type;
+                                glGetActiveUniform(_program, uniformIndex, bufferNameByteCount,
+                                    &actualLength, &size, &type, bufferNamePtr);
+                                string name = Encoding.UTF8.GetString(bufferNamePtr, (int) actualLength);
+                                names.Add(name);
+                                uniformIndex++;
+                            } while (glGetError() == 0);
+                            throw new InvalidOperationException($"Unable to bind uniform texture \"{resourceName}\" by name. Valid names for this pipeline are: {string.Join(", ", names)}");
+                        }
+#endif
+
                         relativeImageIndex += 1;
                         textureBindings[i] = new OpenGLTextureBindingSlotInfo() { RelativeIndex = relativeImageIndex, UniformLocation = location };
                     }

--- a/src/Veldrid/OpenGL/OpenGLPipeline.cs
+++ b/src/Veldrid/OpenGL/OpenGLPipeline.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System;
-using System.Linq;
 
 namespace Veldrid.OpenGL
 {
@@ -246,7 +245,7 @@ namespace Veldrid.OpenGL
                                 uniformBufferIndex++;
                             }
 
-                            throw new VeldridException($"Unable to bind uniform buffer \"{resourceName}\" by name. Valid names for this pipeline are: {string.Join(", ", names.Distinct())}");
+                            throw new VeldridException($"Unable to bind uniform buffer \"{resourceName}\" by name. Valid names for this pipeline are: {string.Join(", ", names)}");
                         }
 #endif
                     }
@@ -362,7 +361,7 @@ namespace Veldrid.OpenGL
                 uniformIndex++;
             }
 
-            throw new VeldridException($"Unable to bind uniform \"{resourceName}\" by name. Valid names for this pipeline are: {string.Join(", ", names.Distinct())}");
+            throw new VeldridException($"Unable to bind uniform \"{resourceName}\" by name. Valid names for this pipeline are: {string.Join(", ", names)}");
         }
 #endif
 


### PR DESCRIPTION
Ran into an issue where shaders were rendering fine with Direct3D & Vulkan, but OpenGL was just giving a black screen. The issue ended up being that OpenGL is much pickier about the names given to resources inside a resource set than the other APIs. 

Unfortunately, there is currently no direct feedback to the developer when this occurs as it just fails silently. This PR simplifies troubleshooting of such issues by adding some debug-mode exceptions, with a message that includes the expected resource names.
