### PR TITLE
Allow Veldrid to run on D3D10-era hardware

### DIFF
--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -59,23 +59,31 @@ namespace Veldrid.D3D11
                 flags = DeviceCreationFlags.Debug;
             }
 
+            SharpDX.Direct3D.FeatureLevel[] featureLevels = new[]
+            {
+                SharpDX.Direct3D.FeatureLevel.Level_11_1,
+                SharpDX.Direct3D.FeatureLevel.Level_11_0,
+                SharpDX.Direct3D.FeatureLevel.Level_10_1,
+                SharpDX.Direct3D.FeatureLevel.Level_10_0
+            };
+
             try
             {
                 _device = new SharpDX.Direct3D11.Device(
                     SharpDX.Direct3D.DriverType.Hardware,
                     flags,
-                    SharpDX.Direct3D.FeatureLevel.Level_11_1);
+                    featureLevels);
             }
             catch (SharpDXException)
             {
                 try
                 {
-                    _device = new SharpDX.Direct3D11.Device(SharpDX.Direct3D.DriverType.Hardware, flags);
+                    _device = new SharpDX.Direct3D11.Device(SharpDX.Direct3D.DriverType.Hardware, flags, featureLevels);
                 }
-                catch (SharpDXException ex) when (debug && (uint)ex.HResult == 0x887A002D)
+                catch (SharpDXException) when (debug)
                 {
                     // The D3D11 debug layer is not installed. Create a normal device without debug support, instead.
-                    _device = new SharpDX.Direct3D11.Device(SharpDX.Direct3D.DriverType.Hardware, DeviceCreationFlags.None);
+                    _device = new SharpDX.Direct3D11.Device(SharpDX.Direct3D.DriverType.Hardware, DeviceCreationFlags.None, featureLevels);
                 }
             }
 


### PR DESCRIPTION
I don't think there's anything in Veldrid's D3D11 backend that prevents it from supporting older GPUs. Just tested my project on a laptop with an NVIDIA 9600M GT (which is a D3D10-era GPU), and this is all I had to change in Veldrid in order for it to work. 

Note that I had to remove the HResult check. That's because on my old laptop I'm getting a different error code when the debug runtime is missing (0x80004005, which can mean pretty much anything).

There's also one thing I'm wondering about. What is the point of trying to create a D3D device twice in a row with the exact same arguments? Could it be that the second call was supposed to have different arguments, and this is just a bug?