### PR TITLE
Add event to optionally abort closing the SDL2 window

### DIFF
--- a/src/Veldrid.SDL2/Sdl2Window.cs
+++ b/src/Veldrid.SDL2/Sdl2Window.cs
@@ -43,6 +43,7 @@ namespace Veldrid.Sdl2
         private string _cachedWindowTitle;
         private bool _newWindowTitleReceived;
         private bool _firstMouseEvent = true;
+        private Func<bool> _closeRequestedHandler;
 
         public Sdl2Window(string title, int x, int y, int width, int height, SDL_WindowFlags flags, bool threadedProcessing)
         {
@@ -244,7 +245,6 @@ namespace Veldrid.Sdl2
         public IntPtr SdlWindowHandle => _window;
 
         public event Action Resized;
-        public event Func<bool> CloseRequested;
         public event Action Closing;
         public event Action Closed;
         public event Action FocusLost;
@@ -282,6 +282,11 @@ namespace Veldrid.Sdl2
 
         public Vector2 MouseDelta => _currentMouseDelta;
 
+        public void SetCloseRequestedHandler(Func<bool> handler)
+        {
+            _closeRequestedHandler = handler;
+        }
+
         public void Close()
         {
             if (_threadedProcessing)
@@ -296,7 +301,7 @@ namespace Veldrid.Sdl2
 
         private bool CloseCore()
         {
-            if (CloseRequested?.Invoke() ?? false)
+            if (_closeRequestedHandler?.Invoke() ?? false)
             {
                 _shouldClose = false;
                 return false;


### PR DESCRIPTION
Subscribing to `CloseRequested` and returning `true` will abort the close action.  This allows users to provide "are you sure?" dialogs, etc.

This will catch both programmatic `Close()` calls and explicit user actions (clicking the window close button, Alt+F4, Cmd+Q).

Tested on macOS by manually inserting into NeoDemo: `_window.CloseRequested += () => true;`