### PR TITLE
Add support for Windows/Command keys

### DIFF
--- a/src/Veldrid.SDL2/ModifierKeys.cs
+++ b/src/Veldrid.SDL2/ModifierKeys.cs
@@ -7,5 +7,6 @@
         Alt = 1,
         Control = 2,
         Shift = 4,
+        Gui = 8,
     }
 }

--- a/src/Veldrid.SDL2/ModifierKeys.cs
+++ b/src/Veldrid.SDL2/ModifierKeys.cs
@@ -7,6 +7,6 @@
         Alt = 1,
         Control = 2,
         Shift = 4,
-        Gui = 8,
+        Super = 8,
     }
 }

--- a/src/Veldrid.SDL2/Sdl2Window.cs
+++ b/src/Veldrid.SDL2/Sdl2Window.cs
@@ -829,7 +829,7 @@ namespace Veldrid.Sdl2
             }
             if ((mod & (SDL_Keymod.LeftGui | SDL_Keymod.RightGui)) != 0)
             {
-                mods |= ModifierKeys.Gui;
+                mods |= ModifierKeys.Super;
             }
 
             return mods;

--- a/src/Veldrid.SDL2/Sdl2Window.cs
+++ b/src/Veldrid.SDL2/Sdl2Window.cs
@@ -803,6 +803,10 @@ namespace Veldrid.Sdl2
                     return Key.ShiftRight;
                 case SDL_Scancode.SDL_SCANCODE_RALT:
                     return Key.AltRight;
+                case SDL_Scancode.SDL_SCANCODE_LGUI:
+                    return Key.LWin;
+                case SDL_Scancode.SDL_SCANCODE_RGUI:
+                    return Key.RWin;
                 default:
                     return Key.Unknown;
             }
@@ -822,6 +826,10 @@ namespace Veldrid.Sdl2
             if ((mod & (SDL_Keymod.LeftControl | SDL_Keymod.RightControl)) != 0)
             {
                 mods |= ModifierKeys.Control;
+            }
+            if ((mod & (SDL_Keymod.LeftGui | SDL_Keymod.RightGui)) != 0)
+            {
+                mods |= ModifierKeys.Gui;
             }
 
             return mods;


### PR DESCRIPTION
Called "Gui" keys in SDL2 scancodes and keymods, so I have mapped the scancodes to the existing `Key.LWin` and `Key.RWin` cases and created a new `Gui` case in `ModifierKeys`.