### PR TITLE
Custom OpenGL TextureTarget

### DIFF
--- a/src/Veldrid.OpenGLBindings/Enums.cs
+++ b/src/Veldrid.OpenGLBindings/Enums.cs
@@ -227,6 +227,7 @@ namespace Veldrid.OpenGLBinding
         Texture2DArray = 35866,
         ProxyTexture2DArray = 35867,
         TextureBuffer = 35882,
+        TextureExternalOes = 36197,
         TextureCubeMapArray = 36873,
         ProxyTextureCubeMapArray = 36875,
         Texture2DMultisample = 37120,

--- a/src/Veldrid/BackendInfoOpenGL.cs
+++ b/src/Veldrid/BackendInfoOpenGL.cs
@@ -1,5 +1,4 @@
-﻿
-#if !EXCLUDE_OPENGL_BACKEND
+﻿#if !EXCLUDE_OPENGL_BACKEND
 using System;
 using Veldrid.OpenGL;
 using Veldrid.OpenGLBinding;

--- a/src/Veldrid/BackendInfoOpenGL.cs
+++ b/src/Veldrid/BackendInfoOpenGL.cs
@@ -1,8 +1,8 @@
 ﻿
-using Veldrid.OpenGLBinding;
 #if !EXCLUDE_OPENGL_BACKEND
 using System;
 using Veldrid.OpenGL;
+using Veldrid.OpenGLBinding;
 
 namespace Veldrid
 {
@@ -40,7 +40,7 @@ namespace Veldrid
         /// Sets the texture target of the OpenGL texture object wrapped by the given Veldrid Texture to to a custom value.
         /// This could be used to set platform specific texture target values like Veldrid.OpenGLBinding.TextureTarget.TextureExternalOes.
         /// </summary>
-        public void SetTextureTarget(Texture texture, uint textureTarget) => Util.AssertSubtype<Texture, OpenGLTexture>(texture).TextureTarget = (Veldrid.OpenGLBinding.TextureTarget)textureTarget;
+        public void SetTextureTarget(Texture texture, uint textureTarget) => Util.AssertSubtype<Texture, OpenGLTexture>(texture).TextureTarget = (TextureTarget)textureTarget;
 
     }
 }

--- a/src/Veldrid/BackendInfoOpenGL.cs
+++ b/src/Veldrid/BackendInfoOpenGL.cs
@@ -1,4 +1,6 @@
-﻿#if !EXCLUDE_OPENGL_BACKEND
+﻿
+using Veldrid.OpenGLBinding;
+#if !EXCLUDE_OPENGL_BACKEND
 using System;
 using Veldrid.OpenGL;
 
@@ -33,6 +35,13 @@ namespace Veldrid
         /// </summary>
         /// <returns>The Veldrid Texture's underlying OpenGL texture name.</returns>
         public uint GetTextureName(Texture texture) => Util.AssertSubtype<Texture, OpenGLTexture>(texture).Texture;
+
+        /// <summary>
+        /// Sets the texture target of the OpenGL texture object wrapped by the given Veldrid Texture to to a custom value.
+        /// This could be used to set platform specific texture target values like Veldrid.OpenGLBinding.TextureTarget.TextureExternalOes.
+        /// </summary>
+        public void SetTextureTarget(Texture texture, uint textureTarget) => Util.AssertSubtype<Texture, OpenGLTexture>(texture).TextureTarget = (Veldrid.OpenGLBinding.TextureTarget)textureTarget;
+
     }
 }
 #endif

--- a/src/Veldrid/OpenGL/OpenGLTexture.cs
+++ b/src/Veldrid/OpenGL/OpenGLTexture.cs
@@ -171,7 +171,6 @@ namespace Veldrid.OpenGL
         public GLPixelFormat GLPixelFormat { get; }
         public GLPixelType GLPixelType { get; }
         public PixelInternalFormat GLInternalFormat { get; }
-
         public TextureTarget TextureTarget { get; internal set; }
 
         public bool Created { get; private set; }

--- a/src/Veldrid/OpenGL/OpenGLTexture.cs
+++ b/src/Veldrid/OpenGL/OpenGLTexture.cs
@@ -17,6 +17,7 @@ namespace Veldrid.OpenGL
 
         private string _name;
         private bool _nameChanged;
+        
         public override string Name { get => _name; set { _name = value; _nameChanged = true; } }
 
         public uint Texture => _texture;
@@ -170,7 +171,8 @@ namespace Veldrid.OpenGL
         public GLPixelFormat GLPixelFormat { get; }
         public GLPixelType GLPixelType { get; }
         public PixelInternalFormat GLInternalFormat { get; }
-        public TextureTarget TextureTarget { get; }
+
+        public TextureTarget TextureTarget { get; internal set; }
 
         public bool Created { get; private set; }
 


### PR DESCRIPTION
Custom OpenGL TextureTarget.

This is required to support platform specific targets like external texture on Android.