### PR TITLE
Added delegates for SDL_GetDesktopDisplayMode and SDL_GetNumVideoDisplays

### DIFF
--- a/src/Veldrid.SDL2/Sdl2.Window.cs
+++ b/src/Veldrid.SDL2/Sdl2.Window.cs
@@ -109,6 +109,16 @@ namespace Veldrid.Sdl2
         private delegate void SDL_SetWindowResizable_t(SDL_Window window, uint resizable);
         private static SDL_SetWindowResizable_t s_setWindowResizable = LoadFunction<SDL_SetWindowResizable_t>("SDL_SetWindowResizable");
         public static void SDL_SetWindowResizable(SDL_Window window, uint resizable) => s_setWindowResizable(window, resizable);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int SDL_GetDesktopDisplayMode_t(int displayIndex, SDL_DisplayMode* mode);
+        private static SDL_GetDesktopDisplayMode_t s_sdl_getDesktopDisplayMode = LoadFunction<SDL_GetDesktopDisplayMode_t>("SDL_GetDesktopDisplayMode");
+        public static int SDL_GetDesktopDisplayMode(int displayIndex, SDL_DisplayMode* mode) => s_sdl_getDesktopDisplayMode(displayIndex, mode);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int SDL_GetNumVideoDisplays_t();
+        private static SDL_GetNumVideoDisplays_t s_sdl_getNumVideoDisplays = LoadFunction<SDL_GetNumVideoDisplays_t>("SDL_GetNumVideoDisplays");
+        public static int SDL_GetNumVideoDisplays() => s_sdl_getNumVideoDisplays();
     }
 
     [Flags]
@@ -198,5 +208,14 @@ namespace Veldrid.Sdl2
         Windowed = 0,
         Fullscreen = 0x00000001,
         FullScreenDesktop = (Fullscreen | 0x00001000),
+    }
+
+    public unsafe struct SDL_DisplayMode
+    {
+        public uint format;
+        public int w;
+        public int h;
+        public int refresh_rate;
+        public void* driverdata;
     }
 }


### PR DESCRIPTION
I needed to use these two functions from SDL and couldn't see them in the Sdl2Native class so just thought I would add them in.
SDL_GetDesktopDisplayMode is useful to get the desktop resolution in a cross-platform way.