### PR TITLE
[OpenGL] Reset the draw buffers after clearing a color target.

### DIFF
--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -77,6 +77,18 @@ namespace Veldrid.OpenGL
             {
                 glEnable(EnableCap.ScissorTest);
             }
+
+            if (!_isSwapchainFB)
+            {
+                int colorCount = _fb.ColorTargets.Count;
+                DrawBuffersEnum* bufs = stackalloc DrawBuffersEnum[colorCount];
+                for (int i = 0; i < colorCount; i++)
+                {
+                    bufs[i] = DrawBuffersEnum.ColorAttachment0 + i;
+                }
+                glDrawBuffers((uint)colorCount, bufs);
+                CheckLastError();
+            }
         }
 
         public void ClearDepthStencil(float depth, byte stencil)


### PR DESCRIPTION
This fixes `OpenGLCommandExecutor.ClearColorTarget` not resetting the draw buffers after clearing the target.
(Fixes #251)