### PR TITLE
[Vulkan] Replace some foreachs that were causing lots of allocations.

### DIFF
--- a/src/Veldrid/Vk/VkCommandList.cs
+++ b/src/Veldrid/Vk/VkCommandList.cs
@@ -319,9 +319,9 @@ namespace Veldrid.Vk
 
                     // Increment ref count on first use of a set.
                     _currentStagingInfo.Resources.Add(vkSet.RefCount);
-                    foreach (ResourceRefCount refCount in vkSet.RefCounts)
+                    for (int i = 0; i < vkSet.RefCounts.Count; i++)
                     {
-                        _currentStagingInfo.Resources.Add(refCount);
+                        _currentStagingInfo.Resources.Add(vkSet.RefCounts[i]);
                     }
                 }
 

--- a/src/Veldrid/Vk/VkFramebuffer.cs
+++ b/src/Veldrid/Vk/VkFramebuffer.cs
@@ -239,8 +239,9 @@ namespace Veldrid.Vk
 
         public override void TransitionToIntermediateLayout(VkCommandBuffer cb)
         {
-            foreach (FramebufferAttachment ca in ColorTargets)
+            for (int i = 0; i < ColorTargets.Count; i++)
             {
+                FramebufferAttachment ca = ColorTargets[i];
                 VkTexture vkTex = Util.AssertSubtype<Texture, VkTexture>(ca.Target);
                 vkTex.SetImageLayout(ca.MipLevel, ca.ArrayLayer, VkImageLayout.ColorAttachmentOptimal);
             }
@@ -256,8 +257,9 @@ namespace Veldrid.Vk
 
         public override void TransitionToFinalLayout(VkCommandBuffer cb)
         {
-            foreach (FramebufferAttachment ca in ColorTargets)
+            for (int i = 0; i < ColorTargets.Count; i++)
             {
+                FramebufferAttachment ca = ColorTargets[i];
                 VkTexture vkTex = Util.AssertSubtype<Texture, VkTexture>(ca.Target);
                 if ((vkTex.Usage & TextureUsage.Sampled) != 0)
                 {


### PR DESCRIPTION
These instances of `foreach` were causing a lot of allocations, making the GC trigger extremely often.