### PR TITLE
fixed for layerless cubemap binding

### DIFF
--- a/src/Veldrid.OpenGLBindings/OpenGLNative.cs
+++ b/src/Veldrid.OpenGLBindings/OpenGLNative.cs
@@ -870,6 +870,19 @@ namespace Veldrid.OpenGLBinding
             => p_glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 
         [UnmanagedFunctionPointer(CallConv)]
+        private delegate void glFramebufferTexture_t(
+            FramebufferTarget target,
+            GLFramebufferAttachment attachment,
+            uint texture,
+            int level);
+        private static glFramebufferTexture_t p_glFramebufferTexture;
+        public static void glFramebufferTexture(
+            FramebufferTarget target,
+            GLFramebufferAttachment attachment,
+            uint texture,
+            int level) => p_glFramebufferTexture(target, attachment, texture, level);
+
+        [UnmanagedFunctionPointer(CallConv)]
         private delegate void glFramebufferTextureLayer_t(
             FramebufferTarget target,
             GLFramebufferAttachment attachment,
@@ -1813,6 +1826,7 @@ namespace Veldrid.OpenGLBinding
             LoadFunction("glTexImage3DMultisample", out p_glTexImage3DMultisample);
             LoadFunction("glBlitFramebuffer", out p_glBlitFramebuffer);
             LoadFunction("glFramebufferTextureLayer", out p_glFramebufferTextureLayer);
+            LoadFunction("glFramebufferTexture", out p_glFramebufferTexture);
             LoadFunction("glDispatchCompute", out p_glDispatchCompute);
             LoadFunction("glGetProgramResourceIndex", out p_glGetProgramResourceIndex);
             LoadFunction("glShaderStorageBlockBinding", out p_glShaderStorageBlockBinding);

--- a/src/Veldrid/OpenGL/OpenGLFramebuffer.cs
+++ b/src/Veldrid/OpenGL/OpenGLFramebuffer.cs
@@ -119,7 +119,17 @@ namespace Veldrid.OpenGL
                     framebufferAttachment = GLFramebufferAttachment.DepthStencilAttachment;
                 }
 
-                if (glDepthTex.ArrayLayers == 1)
+                if (glDepthTex.TextureTarget == TextureTarget.TextureCubeMap)
+                {
+                    glFramebufferTexture(
+                      FramebufferTarget.Framebuffer,
+                      framebufferAttachment,
+                      glDepthTex.Texture,
+                      (int)DepthTarget.Value.MipLevel);
+                    CheckLastError();
+                }
+
+                else if (glDepthTex.ArrayLayers == 1)
                 {
                     glFramebufferTexture2D(
                         FramebufferTarget.Framebuffer,


### PR DESCRIPTION
This is a fix for what Doom2Fan tried to do with his pull request. We needed the  glFramebufferTexture https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFramebufferTexture.xhtml, without a layer. Otherwise only one cubemap layer was writable as a framebuffer target. Im not sure about his code, it might be redundant now. But I left it in