### PR TITLE
Add support for layered framebuffers

### DIFF
--- a/src/Veldrid.OpenGLBindings/OpenGLNative.cs
+++ b/src/Veldrid.OpenGLBindings/OpenGLNative.cs
@@ -870,6 +870,19 @@ namespace Veldrid.OpenGLBinding
             => p_glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 
         [UnmanagedFunctionPointer(CallConv)]
+        private delegate void glFramebufferTexture_t(
+            FramebufferTarget target,
+            GLFramebufferAttachment attachment,
+            uint texture,
+            int level);
+        private static glFramebufferTexture_t p_glFramebufferTexture;
+        public static void glFramebufferTexture(
+            FramebufferTarget target,
+            GLFramebufferAttachment attachment,
+            uint texture,
+            int level) => p_glFramebufferTexture(target, attachment, texture, level);
+
+        [UnmanagedFunctionPointer(CallConv)]
         private delegate void glFramebufferTextureLayer_t(
             FramebufferTarget target,
             GLFramebufferAttachment attachment,
@@ -1814,6 +1827,7 @@ namespace Veldrid.OpenGLBinding
             LoadFunction("glBlitFramebuffer", out p_glBlitFramebuffer);
             LoadFunction("glFramebufferTextureLayer", out p_glFramebufferTextureLayer);
             LoadFunction("glDispatchCompute", out p_glDispatchCompute);
+            LoadFunction("glFramebufferTexture", out p_glFramebufferTexture);
             LoadFunction("glGetProgramResourceIndex", out p_glGetProgramResourceIndex);
             LoadFunction("glShaderStorageBlockBinding", out p_glShaderStorageBlockBinding);
             LoadFunction("glDrawElementsIndirect", out p_glDrawElementsIndirect);

--- a/src/Veldrid/Framebuffer.cs
+++ b/src/Veldrid/Framebuffer.cs
@@ -48,7 +48,8 @@ namespace Veldrid
                 DepthTarget = new FramebufferAttachment(
                     depthAttachment.Target,
                     depthAttachment.ArrayLayer,
-                    depthAttachment.MipLevel);
+                    depthAttachment.MipLevel,
+                    depthAttachment.LayeredTarget);
             }
             FramebufferAttachment[] colorTargets = new FramebufferAttachment[colorTargetDescs.Count];
             for (int i = 0; i < colorTargets.Length; i++)
@@ -56,7 +57,8 @@ namespace Veldrid
                 colorTargets[i] = new FramebufferAttachment(
                     colorTargetDescs[i].Target,
                     colorTargetDescs[i].ArrayLayer,
-                    colorTargetDescs[i].MipLevel);
+                    colorTargetDescs[i].MipLevel,
+                    colorTargetDescs[i].LayeredTarget);
             }
 
             ColorTargets = colorTargets;

--- a/src/Veldrid/FramebufferAttachment.cs
+++ b/src/Veldrid/FramebufferAttachment.cs
@@ -17,6 +17,10 @@
         /// The target mip level.
         /// </summary>
         public uint MipLevel { get; }
+        /// <summary>
+        /// Indicates whether the target should be bound as a layered target. Used for texture arrays and cubemaps.
+        /// </summary>
+        public bool LayeredTarget { get; }
 
         /// <summary>
         /// Constructs a new FramebufferAttachment.
@@ -28,6 +32,7 @@
             Target = target;
             ArrayLayer = arrayLayer;
             MipLevel = 0;
+            LayeredTarget = false;
         }
 
         /// <summary>
@@ -41,6 +46,22 @@
             Target = target;
             ArrayLayer = arrayLayer;
             MipLevel = mipLevel;
+            LayeredTarget = false;
+        }
+
+        /// <summary>
+        /// Constructs a new FramebufferAttachment.
+        /// </summary>
+        /// <param name="target">The target <see cref="Texture"/> which will be rendered to.</param>
+        /// <param name="arrayLayer">The target array layer.</param>
+        /// <param name="mipLevel">The target mip level.</param>
+        /// <param name="layeredTarget">Whether to bind the target as a layered target.</param>
+        public FramebufferAttachment(Texture target, uint arrayLayer, uint mipLevel, bool layeredTarget)
+        {
+            Target = target;
+            ArrayLayer = arrayLayer;
+            MipLevel = mipLevel;
+            LayeredTarget = layeredTarget;
         }
     }
 }

--- a/src/Veldrid/FramebufferAttachmentDescription.cs
+++ b/src/Veldrid/FramebufferAttachmentDescription.cs
@@ -23,6 +23,29 @@ namespace Veldrid
         /// <see cref="Texture"/>.
         /// </summary>
         public uint MipLevel;
+        /// <summary>
+        /// Indicates whether the target should be bound as a layered target. Used for texture arrays and cubemaps.
+        /// </summary>
+        public bool LayeredTarget;
+
+        /// <summary>
+        /// Constructs a new FramebufferAttachmentDescription.
+        /// </summary>
+        /// <param name="target">The target texture to render into. For color attachments, this resource must have been created
+        /// with the <see cref="TextureUsage.RenderTarget"/> flag. For depth attachments, this resource must have been created
+        /// with the <see cref="TextureUsage.DepthStencil"/> flag.</param>
+        public FramebufferAttachmentDescription(Texture target)
+            : this(target, 0, 0)
+        {
+            if ((target.Usage & TextureUsage.Cubemap) != 0)
+            {
+                LayeredTarget = true;
+            }
+            else if (target.ArrayLayers > 1)
+            {
+                LayeredTarget = true;
+            }
+        }
 
         /// <summary>
         /// Constructs a new FramebufferAttachmentDescription.
@@ -69,6 +92,7 @@ namespace Veldrid
             Target = target;
             ArrayLayer = arrayLayer;
             MipLevel = mipLevel;
+            LayeredTarget = false;
         }
 
         /// <summary>

--- a/src/Veldrid/FramebufferDescription.cs
+++ b/src/Veldrid/FramebufferDescription.cs
@@ -30,7 +30,7 @@ namespace Veldrid
         {
             if (depthTarget != null)
             {
-                DepthTarget = new FramebufferAttachmentDescription(depthTarget, 0);
+                DepthTarget = new FramebufferAttachmentDescription(depthTarget);
             }
             else
             {
@@ -39,7 +39,7 @@ namespace Veldrid
             ColorTargets = new FramebufferAttachmentDescription[colorTargets.Length];
             for (int i = 0; i < colorTargets.Length; i++)
             {
-                ColorTargets[i] = new FramebufferAttachmentDescription(colorTargets[i], 0);
+                ColorTargets[i] = new FramebufferAttachmentDescription(colorTargets[i]);
             }
         }
 

--- a/src/Veldrid/ValidationHelpers.cs
+++ b/src/Veldrid/ValidationHelpers.cs
@@ -124,5 +124,31 @@ namespace Veldrid
                     throw Illegal.Value<ResourceKind>();
             }
         }
+
+        [Conditional ("VALIDATE_USAGE")]
+        internal static void ValidateFramebufferDescription(FramebufferDescription description)
+        {
+            bool hasSingleTargets = false;
+            bool hasLayeredTargets = false;
+
+            for (int i = 0; i < description.ColorTargets.Length; i++)
+            {
+                bool isLayeredTarget = description.ColorTargets[i].LayeredTarget;
+                hasSingleTargets |= !isLayeredTarget;
+                hasLayeredTargets |= isLayeredTarget;
+            }
+
+            if (description.DepthTarget != null)
+            {
+                bool isLayeredTarget = description.DepthTarget.Value.LayeredTarget;
+                hasSingleTargets |= !isLayeredTarget;
+                hasLayeredTargets |= isLayeredTarget;
+            }
+
+            if (hasSingleTargets && hasLayeredTargets)
+            {
+                throw new VeldridException ("Non-layered and layered attachments cannot be used in a single framebuffer.");
+            }
+        }
     }
 }

--- a/src/Veldrid/Vk/VkCommandList.cs
+++ b/src/Veldrid/Vk/VkCommandList.cs
@@ -185,11 +185,14 @@ namespace Veldrid.Vk
                     clearValue = clearValue
                 };
 
-                Texture colorTex = _currentFramebuffer.ColorTargets[(int)index].Target;
+                FramebufferAttachment ca = _currentFramebuffer.ColorTargets[(int)index];
+                Texture colorTex = ca.Target;
+
+                GetTextureArrayAttachmentData(ca, out uint arraySize, out uint arrayLayer);
                 VkClearRect clearRect = new VkClearRect
                 {
-                    baseArrayLayer = 0,
-                    layerCount = 1,
+                    baseArrayLayer = arrayLayer,
+                    layerCount = arraySize,
                     rect = new VkRect2D(0, 0, colorTex.Width, colorTex.Height)
                 };
 
@@ -222,10 +225,11 @@ namespace Veldrid.Vk
                 uint renderableHeight = _currentFramebuffer.RenderableHeight;
                 if (renderableWidth > 0 && renderableHeight > 0)
                 {
+                    GetTextureArrayAttachmentData(_currentFramebuffer.DepthTarget.Value, out uint arraySize, out uint arrayLayer);
                     VkClearRect clearRect = new VkClearRect
                     {
-                        baseArrayLayer = 0,
-                        layerCount = 1,
+                        baseArrayLayer = arrayLayer,
+                        layerCount = arraySize,
                         rect = new VkRect2D(0, 0, renderableWidth, renderableHeight)
                     };
 

--- a/src/Veldrid/Vk/VulkanUtil.cs
+++ b/src/Veldrid/Vk/VulkanUtil.cs
@@ -281,6 +281,46 @@ namespace Veldrid.Vk
                 0, null,
                 1, &barrier);
         }
+
+        public static void GetTextureArrayAttachmentData(FramebufferAttachmentDescription fbAttachment, out uint arraySize, out uint arrayLayer)
+        {
+            VkTexture vkTexture = Util.AssertSubtype<Texture, VkTexture>(fbAttachment.Target);
+            bool isCubemap = (vkTexture.Usage & TextureUsage.Cubemap) != 0;
+
+            arraySize = 1;
+            arrayLayer = fbAttachment.ArrayLayer;
+
+            if (fbAttachment.LayeredTarget)
+            {
+                arraySize = vkTexture.ArrayLayers;
+                arrayLayer = 0;
+
+                if (isCubemap)
+                {
+                    arraySize *= 6;
+                }
+            }
+        }
+
+        public static void GetTextureArrayAttachmentData (FramebufferAttachment fbAttachment, out uint arraySize, out uint arrayLayer)
+        {
+            VkTexture vkTexture = Util.AssertSubtype<Texture, VkTexture>(fbAttachment.Target);
+            bool isCubemap = (vkTexture.Usage & TextureUsage.Cubemap) != 0;
+
+            arraySize = 1;
+            arrayLayer = fbAttachment.ArrayLayer;
+
+            if (fbAttachment.LayeredTarget)
+            {
+                arraySize = vkTexture.ArrayLayers;
+                arrayLayer = 0;
+
+                if (isCubemap)
+                {
+                    arraySize *= 6;
+                }
+            }
+        }
     }
 
     internal unsafe static class VkPhysicalDeviceMemoryPropertiesEx


### PR DESCRIPTION
Layered framebuffers are useful as they can be used to render geometry to things like cubemaps in a single drawcall through geometry shaders.
Originally I was going to add an option to let the user specify how many layers to bind instead, but it appears OpenGL doesn't support this, so I had to scrap that and bind all layers instead.

Unfortunately, actually drawing anything is untested, as I have no geometry shaders to test it with, and Veldrid.Spirv can't compile geometry shaders anyway.
But at least OpenGL *should* work, as I based that on PR #270, and that supposedly works.

Issues:
* OpenGL won't clear the stencils for some reason. (Might be all stencil writing that won't work? Couldn't test, see last one)
* No Metal implementation. (Don't know Metal and can't test)
* Couldn't test drawing to all layers due to lack of geometry shaders.