### PR TITLE
[D3D11] add support for the WPF D3D11Image Control

### DIFF
--- a/src/Veldrid/D3D11/D3D11Texture.cs
+++ b/src/Veldrid/D3D11/D3D11Texture.cs
@@ -167,6 +167,26 @@ namespace Veldrid.D3D11
             TypelessDxgiFormat = D3D11Formats.GetTypelessFormat(DxgiFormat);
         }
 
+        public D3D11Texture(Texture2D existingTexture)
+        {
+            _device = existingTexture.Device;
+            DeviceTexture = existingTexture;
+            Width = (uint)existingTexture.Description.Width;
+            Height = (uint)existingTexture.Description.Height;
+            Depth = 1;
+            MipLevels = (uint)existingTexture.Description.MipLevels;
+            ArrayLayers = (uint)existingTexture.Description.ArraySize;
+            Format = D3D11Formats.ToVdFormat(existingTexture.Description.Format);
+            SampleCount = FormatHelpers.GetSampleCount((uint)existingTexture.Description.SampleDescription.Count);
+            Type = TextureType.Texture2D;
+            Usage = D3D11Formats.GetVdUsage(
+                existingTexture.Description.BindFlags,
+                existingTexture.Description.CpuAccessFlags,
+                existingTexture.Description.OptionFlags);
+            DxgiFormat = existingTexture.Description.Format;
+            TypelessDxgiFormat = D3D11Formats.GetTypelessFormat(DxgiFormat);
+        }
+
         private protected override TextureView CreateFullTextureView(GraphicsDevice gd)
         {
             TextureViewDescription desc = new TextureViewDescription(this);

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -962,6 +962,13 @@ namespace Veldrid
 
             return new D3D11.D3D11GraphicsDevice(options, new D3D11DeviceOptions(), swapchainDescription);
         }
+
+        public static GraphicsDevice CreateD3D11(SharpDX.Direct3D11.Device device)
+        {
+            if (device == null) return null;
+            return new D3D11.D3D11GraphicsDevice(device);
+        }
+
 #endif
 
 #if !EXCLUDE_VULKAN_BACKEND

--- a/src/Veldrid/Texture.cs
+++ b/src/Veldrid/Texture.cs
@@ -102,5 +102,20 @@ namespace Veldrid
         }
 
         private protected abstract void DisposeCore();
+
+        #region --- public static
+
+#if !EXCLUDE_D3D11_BACKEND
+
+        public static Texture CreateD3D11(SharpDX.Direct3D11.Texture2D texture)
+        {
+            if (texture == null) return null;
+            return new Veldrid.D3D11.D3D11Texture(texture);
+        }
+
+#endif
+
+        #endregion
+
     }
 }


### PR DESCRIPTION
The proposed pull request contains the minimal modifications necessary to connect Veldrid to WPF D3D11Image like:

```
    <Grid Background="DarkBlue">
        
        <Image Stretch="None" Name="ImageHost" Margin="32">
            <Image.Source>
                <dx:D3D11Image x:Name="InteropImage" />
            </Image.Source>
        </Image>
        <Button x:Name="bnTest" Width="200" Height="50" Click="BnTest_Click" Margin="8" Content="Test"/>

    </Grid>

```

`InteropImage.OnRender = this.doRender;
`

```
        Veldrid.D3D11.D3D11GraphicsDevice _graphicsDevice;

        Veldrid.D3D11.D3D11GraphicsDevice graphicsDevice
        {
            get
            {
                if (_graphicsDevice == null)
                {
                    GraphicsDeviceOptions _options = new GraphicsDeviceOptions(false, null, false, ResourceBindingModel.Improved);
                    _graphicsDevice = GraphicsDevice.CreateD3D11(_options) as Veldrid.D3D11.D3D11GraphicsDevice;
                }
                return _graphicsDevice;
            }
        }

        Framebuffer _framebuffer;

        Framebuffer frameBuffer(IntPtr surface, bool isNewSurface)
        {
            if (isNewSurface)
            {
                if (_framebuffer != null)
                {
                    _framebuffer.Dispose();
                    _framebuffer = null;
                }
            }

            if (_framebuffer == null)
            {
                Veldrid.D3D11.D3D11GraphicsDevice _graphicsDevice = graphicsDevice;
                SharpDX.Direct3D11.Device _deviceD11 = _graphicsDevice?.Device;
                if (_deviceD11 == null) return null;

                using (var _ComObject = new SharpDX.ComObject(surface))
                {
                    Texture2D _texture2D = null;
                    Texture _texture = null;
                    try
                    {
                        var _dxgiResource = _ComObject.QueryInterface<SharpDX.DXGI.Resource>(); // PAS de .Dispose

                        _texture2D = _deviceD11.OpenSharedResource<Texture2D>(_dxgiResource.SharedHandle);

                        _texture = Texture.CreateD3D11(_texture2D);

                        _framebuffer = _graphicsDevice.ResourceFactory.CreateFramebuffer(new FramebufferDescription(null, _texture));
                    }
                    finally
                    {
                        _texture?.Dispose();
                        _texture2D?.Dispose();
                    }
                }
            }

            return _framebuffer;
        }

        private void doRender(IntPtr surface, bool isNewSurface)
        {
            int _doRender = ++m_doRender;

            Veldrid.D3D11.D3D11GraphicsDevice _graphicsDevice = graphicsDevice;
            SharpDX.Direct3D11.Device _deviceD11 = _graphicsDevice?.Device;
            if (_deviceD11 == null) return;

            Framebuffer _framebuffer = frameBuffer(surface, isNewSurface);
            if (_framebuffer == null) return;

            {
                Veldrid.CommandList _commandList = null;
                try
                {
                    _commandList = _graphicsDevice.ResourceFactory.CreateCommandList();
                    if (_commandList == null) return;

                    _commandList.Begin();

                    _commandList.SetFramebuffer(_framebuffer);

                    _commandList.ClearColorTarget(0, RgbaFloat.Pink);

                    _commandList.End();

                    _graphicsDevice.SubmitCommands(_commandList);
                }
                catch (Exception E)
                {
                }
                finally
                {
                    _commandList?.Dispose();
                }
            }

            _deviceD11.ImmediateContext.Flush();

        }

```
