### PR TITLE
Add key repeat info to KeyEvent

### DIFF
--- a/src/Veldrid.SDL2/KeyEvent.cs
+++ b/src/Veldrid.SDL2/KeyEvent.cs
@@ -5,14 +5,16 @@
         public Key Key { get; }
         public bool Down { get; }
         public ModifierKeys Modifiers { get; }
-        public KeyEvent(Key key, bool down, ModifierKeys modifiers)
+        public bool Repeat { get; }
+        public KeyEvent(Key key, bool down, ModifierKeys modifiers, bool repeat = false)
         {
             Key = key;
             Down = down;
             Modifiers = modifiers;
+            Repeat = repeat;
         }
 
-        public override string ToString() => $"{Key} {(Down ? "Down" : "Up")} [{Modifiers}]";
+        public override string ToString() => $"{Key} {(Down ? "Down" : "Up")} [{Modifiers}] (repeat={Repeat})";
     }
 
     public enum Key

--- a/src/Veldrid.SDL2/Sdl2Window.cs
+++ b/src/Veldrid.SDL2/Sdl2Window.cs
@@ -568,7 +568,7 @@ namespace Veldrid.Sdl2
         private void HandleKeyboardEvent(SDL_KeyboardEvent keyboardEvent)
         {
             SimpleInputSnapshot snapshot = _privateSnapshot;
-            KeyEvent keyEvent = new KeyEvent(MapKey(keyboardEvent.keysym), keyboardEvent.state == 1, MapModifierKeys(keyboardEvent.keysym.mod));
+            KeyEvent keyEvent = new KeyEvent(MapKey(keyboardEvent.keysym), keyboardEvent.state == 1, MapModifierKeys(keyboardEvent.keysym.mod), keyboardEvent.repeat == 1);
             snapshot.KeyEventsList.Add(keyEvent);
             if (keyboardEvent.state == 1)
             {


### PR DESCRIPTION
Small change to add key repeat info to KeyEvent

Also - quick question - what's the policy on breakages for Veldrid? If I didn't have the default parameter for `repeat` on the `KeyEvent` constructor, would that be a breaking change? If so, would you have to release a new major version? i.e. `5.0.0`, or would it be a minor version increment? i.e. `4.8.0`

Also - is the change of the `ToString` function breaking behaviour, in your opinion?