### PR TITLE
Make SDL_ControllerDeviceEvent public

### DIFF
--- a/src/Veldrid.SDL2/Sdl2.GameController.cs
+++ b/src/Veldrid.SDL2/Sdl2.GameController.cs
@@ -79,7 +79,7 @@ namespace Veldrid.Sdl2
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    struct SDL_ControllerDeviceEvent
+    public struct SDL_ControllerDeviceEvent
     {
         /// <summary>
         /// SDL_CONTROLLERDEVICEADDED, SDL_CONTROLLERDEVICEREMOVED, or SDL_CONTROLLERDEVICEREMAPPED.


### PR DESCRIPTION
Seems like an oversight - I'm going to use this event to handle the ControllerDeviceAdded/Removed/Remapped events https://wiki.libsdl.org/SDL_ControllerDeviceEvent