### PR TITLE
Replace SharpDX with Vortice.Windows

### DIFF
--- a/src/Veldrid.MetalBindings/Veldrid.MetalBindings.csproj
+++ b/src/Veldrid.MetalBindings/Veldrid.MetalBindings.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Veldrid.SDL2/Veldrid.SDL2.csproj
+++ b/src/Veldrid.SDL2/Veldrid.SDL2.csproj
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="NativeLibraryLoader" Version="$(NativeLibraryLoaderVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
-    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Veldrid/D3D11/D3D11Buffer.cs
+++ b/src/Veldrid/D3D11/D3D11Buffer.cs
@@ -1,19 +1,20 @@
 ﻿using System;
-using SharpDX.Direct3D11;
-using System.Diagnostics;
+using Vortice.Direct3D11;
 using System.Collections.Generic;
+using Vortice.DXGI;
+using Vortice.Direct3D;
 
 namespace Veldrid.D3D11
 {
     internal class D3D11Buffer : DeviceBuffer
     {
-        private readonly Device _device;
-        private readonly SharpDX.Direct3D11.Buffer _buffer;
+        private readonly ID3D11Device _device;
+        private readonly ID3D11Buffer _buffer;
         private readonly object _accessViewLock = new object();
-        private readonly Dictionary<OffsetSizePair, ShaderResourceView> _srvs
-            = new Dictionary<OffsetSizePair, ShaderResourceView>();
-        private readonly Dictionary<OffsetSizePair, UnorderedAccessView> _uavs
-            = new Dictionary<OffsetSizePair, UnorderedAccessView>();
+        private readonly Dictionary<OffsetSizePair, ID3D11ShaderResourceView> _srvs
+            = new Dictionary<OffsetSizePair, ID3D11ShaderResourceView>();
+        private readonly Dictionary<OffsetSizePair, ID3D11UnorderedAccessView> _uavs
+            = new Dictionary<OffsetSizePair, ID3D11UnorderedAccessView>();
         private readonly uint _structureByteStride;
         private readonly bool _rawBuffer;
         private string _name;
@@ -24,19 +25,20 @@ namespace Veldrid.D3D11
 
         public override bool IsDisposed => _buffer.IsDisposed;
 
-        public SharpDX.Direct3D11.Buffer Buffer => _buffer;
+        public ID3D11Buffer Buffer => _buffer;
 
-        public D3D11Buffer(Device device, uint sizeInBytes, BufferUsage usage, uint structureByteStride, bool rawBuffer)
+        public D3D11Buffer(ID3D11Device device, uint sizeInBytes, BufferUsage usage, uint structureByteStride, bool rawBuffer)
         {
             _device = device;
             SizeInBytes = sizeInBytes;
             Usage = usage;
             _structureByteStride = structureByteStride;
             _rawBuffer = rawBuffer;
-            SharpDX.Direct3D11.BufferDescription bd = new SharpDX.Direct3D11.BufferDescription(
+
+            Vortice.Direct3D11.BufferDescription bd = new Vortice.Direct3D11.BufferDescription(
                 (int)sizeInBytes,
                 D3D11Formats.VdToD3D11BindFlags(usage),
-                ResourceUsage.Default);
+                Vortice.Direct3D11.Usage.Default);
             if ((usage & BufferUsage.StructuredBufferReadOnly) == BufferUsage.StructuredBufferReadOnly
                 || (usage & BufferUsage.StructuredBufferReadWrite) == BufferUsage.StructuredBufferReadWrite)
             {
@@ -52,21 +54,21 @@ namespace Veldrid.D3D11
             }
             if ((usage & BufferUsage.IndirectBuffer) == BufferUsage.IndirectBuffer)
             {
-                bd.OptionFlags = ResourceOptionFlags.DrawIndirectArguments;
+                bd.OptionFlags = ResourceOptionFlags.DrawIndirectArgs;
             }
 
             if ((usage & BufferUsage.Dynamic) == BufferUsage.Dynamic)
             {
-                bd.Usage = ResourceUsage.Dynamic;
+                bd.Usage = Vortice.Direct3D11.Usage.Dynamic;
                 bd.CpuAccessFlags = CpuAccessFlags.Write;
             }
             else if ((usage & BufferUsage.Staging) == BufferUsage.Staging)
             {
-                bd.Usage = ResourceUsage.Staging;
+                bd.Usage = Vortice.Direct3D11.Usage.Staging;
                 bd.CpuAccessFlags = CpuAccessFlags.Read | CpuAccessFlags.Write;
             }
 
-            _buffer = new SharpDX.Direct3D11.Buffer(device, bd);
+            _buffer = device.CreateBuffer(bd);
         }
 
         public override string Name
@@ -76,11 +78,11 @@ namespace Veldrid.D3D11
             {
                 _name = value;
                 Buffer.DebugName = value;
-                foreach (KeyValuePair<OffsetSizePair, ShaderResourceView> kvp in _srvs)
+                foreach (KeyValuePair<OffsetSizePair, ID3D11ShaderResourceView> kvp in _srvs)
                 {
                     kvp.Value.DebugName = value + "_SRV";
                 }
-                foreach (KeyValuePair<OffsetSizePair, UnorderedAccessView> kvp in _uavs)
+                foreach (KeyValuePair<OffsetSizePair, ID3D11UnorderedAccessView> kvp in _uavs)
                 {
                     kvp.Value.DebugName = value + "_UAV";
                 }
@@ -89,23 +91,23 @@ namespace Veldrid.D3D11
 
         public override void Dispose()
         {
-            foreach (KeyValuePair<OffsetSizePair, ShaderResourceView> kvp in _srvs)
+            foreach (KeyValuePair<OffsetSizePair, ID3D11ShaderResourceView> kvp in _srvs)
             {
                 kvp.Value.Dispose();
             }
-            foreach (KeyValuePair<OffsetSizePair, UnorderedAccessView> kvp in _uavs)
+            foreach (KeyValuePair<OffsetSizePair, ID3D11UnorderedAccessView> kvp in _uavs)
             {
                 kvp.Value.Dispose();
             }
             _buffer.Dispose();
         }
 
-        internal ShaderResourceView GetShaderResourceView(uint offset, uint size)
+        internal ID3D11ShaderResourceView GetShaderResourceView(uint offset, uint size)
         {
             lock (_accessViewLock)
             {
                 OffsetSizePair pair = new OffsetSizePair(offset, size);
-                if (!_srvs.TryGetValue(pair, out ShaderResourceView srv))
+                if (!_srvs.TryGetValue(pair, out ID3D11ShaderResourceView srv))
                 {
                     srv = CreateShaderResourceView(offset, size);
                     _srvs.Add(pair, srv);
@@ -115,12 +117,12 @@ namespace Veldrid.D3D11
             }
         }
 
-        internal UnorderedAccessView GetUnorderedAccessView(uint offset, uint size)
+        internal ID3D11UnorderedAccessView GetUnorderedAccessView(uint offset, uint size)
         {
             lock (_accessViewLock)
             {
                 OffsetSizePair pair = new OffsetSizePair(offset, size);
-                if (!_uavs.TryGetValue(pair, out UnorderedAccessView uav))
+                if (!_uavs.TryGetValue(pair, out ID3D11UnorderedAccessView uav))
                 {
                     uav = CreateUnorderedAccessView(offset, size);
                     _uavs.Add(pair, uav);
@@ -130,61 +132,61 @@ namespace Veldrid.D3D11
             }
         }
 
-        private ShaderResourceView CreateShaderResourceView(uint offset, uint size)
+        private ID3D11ShaderResourceView CreateShaderResourceView(uint offset, uint size)
         {
             if (_rawBuffer)
             {
                 ShaderResourceViewDescription srvDesc = new ShaderResourceViewDescription
                 {
-                    Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.ExtendedBuffer,
-                    Format = SharpDX.DXGI.Format.R32_Typeless
+                    ViewDimension = ShaderResourceViewDimension.BufferExtended,
+                    Format = Format.R32_Typeless
                 };
-                srvDesc.BufferEx.ElementCount = (int)size / 4;
-                srvDesc.BufferEx.Flags = ShaderResourceViewExtendedBufferFlags.Raw;
+                srvDesc.BufferEx.NumElements = (int)size / 4;
+                srvDesc.BufferEx.Flags = BufferExtendedShaderResourceViewFlag.Raw;
                 srvDesc.BufferEx.FirstElement = (int)offset / 4;
-                return new ShaderResourceView(_device, _buffer, srvDesc);
+                return _device.CreateShaderResourceView(_buffer, srvDesc);
             }
             else
             {
                 ShaderResourceViewDescription srvDesc = new ShaderResourceViewDescription
                 {
-                    Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Buffer
+                    ViewDimension = ShaderResourceViewDimension.Buffer
                 };
-                srvDesc.Buffer.ElementCount = (int)(size / _structureByteStride);
+                srvDesc.Buffer.NumElements = (int)(size / _structureByteStride);
                 srvDesc.Buffer.ElementOffset = (int)(offset / _structureByteStride);
-                return new ShaderResourceView(_device, _buffer, srvDesc);
+                return _device.CreateShaderResourceView(_buffer, srvDesc);
             }
         }
 
-        private UnorderedAccessView CreateUnorderedAccessView(uint offset, uint size)
+        private ID3D11UnorderedAccessView CreateUnorderedAccessView(uint offset, uint size)
         {
             if (_rawBuffer)
             {
                 UnorderedAccessViewDescription uavDesc = new UnorderedAccessViewDescription
                 {
-                    Dimension = UnorderedAccessViewDimension.Buffer
+                    ViewDimension = UnorderedAccessViewDimension.Buffer
                 };
 
-                uavDesc.Buffer.ElementCount = (int)size / 4;
-                uavDesc.Buffer.Flags = UnorderedAccessViewBufferFlags.Raw;
-                uavDesc.Format = SharpDX.DXGI.Format.R32_Typeless;
+                uavDesc.Buffer.NumElements = (int)size / 4;
+                uavDesc.Buffer.Flags = BufferUnorderedAccessViewFlag.Raw;
+                uavDesc.Format = Format.R32_Typeless;
                 uavDesc.Buffer.FirstElement = (int)offset / 4;
 
-                return new UnorderedAccessView(_device, _buffer, uavDesc);
+                return _device.CreateUnorderedAccessView(_buffer, uavDesc);
 
             }
             else
             {
                 UnorderedAccessViewDescription uavDesc = new UnorderedAccessViewDescription
                 {
-                    Dimension = UnorderedAccessViewDimension.Buffer
+                    ViewDimension = UnorderedAccessViewDimension.Buffer
                 };
 
-                uavDesc.Buffer.ElementCount = (int)(size / _structureByteStride);
-                uavDesc.Format = SharpDX.DXGI.Format.Unknown;
+                uavDesc.Buffer.NumElements = (int)(size / _structureByteStride);
+                uavDesc.Format = Format.Unknown;
                 uavDesc.Buffer.FirstElement = (int)(offset / _structureByteStride);
 
-                return new UnorderedAccessView(_device, _buffer, uavDesc);
+                return _device.CreateUnorderedAccessView(_buffer, uavDesc);
             }
         }
 

--- a/src/Veldrid/D3D11/D3D11CommandList.cs
+++ b/src/Veldrid/D3D11/D3D11CommandList.cs
@@ -1199,7 +1199,7 @@ namespace Veldrid.D3D11
                 }
                 else
                 {
-                    System.Buffer.MemoryCopy(source.ToPointer(), msb.DataPointer.ToPointer(), buffer.SizeInBytes, sizeInBytes);
+                    Buffer.MemoryCopy(source.ToPointer(), msb.DataPointer.ToPointer(), buffer.SizeInBytes, sizeInBytes);
                 }
                 _context.Unmap(d3dBuffer.Buffer, 0);
             }
@@ -1254,7 +1254,7 @@ namespace Veldrid.D3D11
 
             Box region = new Box((int)sourceOffset, 0, 0, (int)(sourceOffset + sizeInBytes), 1, 1);
 
-            _context.CopySubresourceRegion(srcD3D11Buffer.Buffer, 0, (int)destinationOffset, 0, 0, dstD3D11Buffer.Buffer, 0, region);
+            _context.CopySubresourceRegion(dstD3D11Buffer.Buffer, 0, (int)destinationOffset, 0, 0, srcD3D11Buffer.Buffer, 0, region);
         }
 
         protected override void CopyTextureCore(
@@ -1295,13 +1295,13 @@ namespace Veldrid.D3D11
                 int dstSubresource = D3D11Util.ComputeSubresource(dstMipLevel, destination.MipLevels, dstBaseArrayLayer + i);
 
                 _context.CopySubresourceRegion(
-                    srcD3D11Texture.DeviceTexture,
-                    srcSubresource,
+                    dstD3D11Texture.DeviceTexture,
+                    dstSubresource,
                     (int)dstX,
                     (int)dstY,
                     (int)dstZ,
-                    dstD3D11Texture.DeviceTexture,
-                    dstSubresource,
+                    srcD3D11Texture.DeviceTexture,
+                    srcSubresource,
                     region);
             }
         }

--- a/src/Veldrid/D3D11/D3D11CommandList.cs
+++ b/src/Veldrid/D3D11/D3D11CommandList.cs
@@ -1026,8 +1026,7 @@ namespace Veldrid.D3D11
             }
             else
             {
-                //TODO:
-                //_context.OMSetRenderTargetsAndUnorderedAccessViews(actualSlot, uav);
+                _context.SetUnorderedAccessViews(actualSlot, new[] { uav }, null);
             }
         }
 
@@ -1057,8 +1056,7 @@ namespace Veldrid.D3D11
                     }
                     else
                     {
-                        //TODO:
-                        //_context.OMSetRenderTargetsAndUnorderedAccessViews(slot, null);
+                        _context.SetUnorderedAccessViews(slot, new ID3D11UnorderedAccessView[] { null }, new[] { -1 });
                     }
 
                     list.RemoveAt(i);

--- a/src/Veldrid/D3D11/D3D11CommandList.cs
+++ b/src/Veldrid/D3D11/D3D11CommandList.cs
@@ -1355,10 +1355,7 @@ namespace Veldrid.D3D11
 
         private protected override void InsertDebugMarkerCore(string name)
         {
-            if (_uda != null)
-            {
-                _uda.Marker = name;
-            }
+            _uda?.SetMarker(name);
         }
 
         public override void Dispose()

--- a/src/Veldrid/D3D11/D3D11Formats.cs
+++ b/src/Veldrid/D3D11/D3D11Formats.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
-using SharpDX.Direct3D;
-using SharpDX.Direct3D11;
-using SharpDX.DXGI;
+using Vortice.Direct3D11;
+using Vortice.DXGI;
 
 namespace Veldrid.D3D11
 {
@@ -311,7 +310,7 @@ namespace Veldrid.D3D11
             {
                 usage |= TextureUsage.Cubemap;
             }
-            if ((optionFlags & ResourceOptionFlags.GenerateMipMaps) != 0)
+            if ((optionFlags & ResourceOptionFlags.GenerateMips) != 0)
             {
                 usage |= TextureUsage.GenerateMipmaps;
             }
@@ -343,34 +342,34 @@ namespace Veldrid.D3D11
             }
         }
 
-        internal static BlendOption VdToD3D11BlendOption(BlendFactor factor)
+        internal static Blend VdToD3D11Blend(BlendFactor factor)
         {
             switch (factor)
             {
                 case BlendFactor.Zero:
-                    return BlendOption.Zero;
+                    return Blend.Zero;
                 case BlendFactor.One:
-                    return BlendOption.One;
+                    return Blend.One;
                 case BlendFactor.SourceAlpha:
-                    return BlendOption.SourceAlpha;
+                    return Blend.SourceAlpha;
                 case BlendFactor.InverseSourceAlpha:
-                    return BlendOption.InverseSourceAlpha;
+                    return Blend.InverseSourceAlpha;
                 case BlendFactor.DestinationAlpha:
-                    return BlendOption.DestinationAlpha;
+                    return Blend.DestinationAlpha;
                 case BlendFactor.InverseDestinationAlpha:
-                    return BlendOption.InverseDestinationAlpha;
+                    return Blend.InverseDestinationAlpha;
                 case BlendFactor.SourceColor:
-                    return BlendOption.SourceColor;
+                    return Blend.SourceColor;
                 case BlendFactor.InverseSourceColor:
-                    return BlendOption.InverseSourceColor;
+                    return Blend.InverseSourceColor;
                 case BlendFactor.DestinationColor:
-                    return BlendOption.DestinationColor;
+                    return Blend.DestinationColor;
                 case BlendFactor.InverseDestinationColor:
-                    return BlendOption.InverseDestinationColor;
+                    return Blend.InverseDestinationColor;
                 case BlendFactor.BlendFactor:
-                    return BlendOption.BlendFactor;
+                    return Blend.BlendFactor;
                 case BlendFactor.InverseBlendFactor:
-                    return BlendOption.BlendFactor;
+                    return Blend.BlendFactor;
                 default:
                     throw Illegal.Value<BlendFactor>();
             }
@@ -389,26 +388,26 @@ namespace Veldrid.D3D11
             }
         }
 
-        internal static SharpDX.Direct3D11.StencilOperation VdToD3D11StencilOperation(StencilOperation op)
+        internal static Vortice.Direct3D11.StencilOperation VdToD3D11StencilOperation(StencilOperation op)
         {
             switch (op)
             {
                 case StencilOperation.Keep:
-                    return SharpDX.Direct3D11.StencilOperation.Keep;
+                    return Vortice.Direct3D11.StencilOperation.Keep;
                 case StencilOperation.Zero:
-                    return SharpDX.Direct3D11.StencilOperation.Zero;
+                    return Vortice.Direct3D11.StencilOperation.Zero;
                 case StencilOperation.Replace:
-                    return SharpDX.Direct3D11.StencilOperation.Replace;
+                    return Vortice.Direct3D11.StencilOperation.Replace;
                 case StencilOperation.IncrementAndClamp:
-                    return SharpDX.Direct3D11.StencilOperation.IncrementAndClamp;
+                    return Vortice.Direct3D11.StencilOperation.IncrSat;
                 case StencilOperation.DecrementAndClamp:
-                    return SharpDX.Direct3D11.StencilOperation.DecrementAndClamp;
+                    return Vortice.Direct3D11.StencilOperation.DecrSat;
                 case StencilOperation.Invert:
-                    return SharpDX.Direct3D11.StencilOperation.Invert;
+                    return Vortice.Direct3D11.StencilOperation.InverseErt;
                 case StencilOperation.IncrementAndWrap:
-                    return SharpDX.Direct3D11.StencilOperation.Increment;
+                    return Vortice.Direct3D11.StencilOperation.Incr;
                 case StencilOperation.DecrementAndWrap:
-                    return SharpDX.Direct3D11.StencilOperation.Decrement;
+                    return Vortice.Direct3D11.StencilOperation.Decr;
                 default:
                     throw Illegal.Value<StencilOperation>();
             }
@@ -553,9 +552,9 @@ namespace Veldrid.D3D11
                 case BlendFunction.ReverseSubtract:
                     return BlendOperation.ReverseSubtract;
                 case BlendFunction.Minimum:
-                    return BlendOperation.Minimum;
+                    return BlendOperation.Min;
                 case BlendFunction.Maximum:
-                    return BlendOperation.Maximum;
+                    return BlendOperation.Max;
                 default:
                     throw Illegal.Value<BlendFunction>();
             }
@@ -588,35 +587,35 @@ namespace Veldrid.D3D11
             }
         }
 
-        internal static SharpDX.Direct3D11.MapMode VdToD3D11MapMode(bool isDynamic, MapMode mode)
+        internal static Vortice.Direct3D11.MapMode VdToD3D11MapMode(bool isDynamic, MapMode mode)
         {
             switch (mode)
             {
                 case MapMode.Read:
-                    return SharpDX.Direct3D11.MapMode.Read;
+                    return Vortice.Direct3D11.MapMode.Read;
                 case MapMode.Write:
-                    return isDynamic ? SharpDX.Direct3D11.MapMode.WriteDiscard : SharpDX.Direct3D11.MapMode.Write;
+                    return isDynamic ? Vortice.Direct3D11.MapMode.WriteDiscard : Vortice.Direct3D11.MapMode.Write;
                 case MapMode.ReadWrite:
-                    return SharpDX.Direct3D11.MapMode.ReadWrite;
+                    return Vortice.Direct3D11.MapMode.ReadWrite;
                 default:
                     throw Illegal.Value<MapMode>();
             }
         }
 
-        internal static SharpDX.Direct3D.PrimitiveTopology VdToD3D11PrimitiveTopology(PrimitiveTopology primitiveTopology)
+        internal static Vortice.Direct3D.PrimitiveTopology VdToD3D11PrimitiveTopology(PrimitiveTopology primitiveTopology)
         {
             switch (primitiveTopology)
             {
                 case PrimitiveTopology.TriangleList:
-                    return SharpDX.Direct3D.PrimitiveTopology.TriangleList;
+                    return Vortice.Direct3D.PrimitiveTopology.TriangleList;
                 case PrimitiveTopology.TriangleStrip:
-                    return SharpDX.Direct3D.PrimitiveTopology.TriangleStrip;
+                    return Vortice.Direct3D.PrimitiveTopology.TriangleStrip;
                 case PrimitiveTopology.LineList:
-                    return SharpDX.Direct3D.PrimitiveTopology.LineList;
+                    return Vortice.Direct3D.PrimitiveTopology.LineList;
                 case PrimitiveTopology.LineStrip:
-                    return SharpDX.Direct3D.PrimitiveTopology.LineStrip;
+                    return Vortice.Direct3D.PrimitiveTopology.LineStrip;
                 case PrimitiveTopology.PointList:
-                    return SharpDX.Direct3D.PrimitiveTopology.PointList;
+                    return Vortice.Direct3D.PrimitiveTopology.PointList;
                 default:
                     throw Illegal.Value<PrimitiveTopology>();
             }
@@ -722,26 +721,26 @@ namespace Veldrid.D3D11
             }
         }
 
-        internal static Comparison VdToD3D11Comparison(ComparisonKind comparisonKind)
+        internal static ComparisonFunction VdToD3D11ComparisonFunc(ComparisonKind comparisonKind)
         {
             switch (comparisonKind)
             {
                 case ComparisonKind.Never:
-                    return Comparison.Never;
+                    return ComparisonFunction.Never;
                 case ComparisonKind.Less:
-                    return Comparison.Less;
+                    return ComparisonFunction.Less;
                 case ComparisonKind.Equal:
-                    return Comparison.Equal;
+                    return ComparisonFunction.Equal;
                 case ComparisonKind.LessEqual:
-                    return Comparison.LessEqual;
+                    return ComparisonFunction.LessEqual;
                 case ComparisonKind.Greater:
-                    return Comparison.Greater;
+                    return ComparisonFunction.Greater;
                 case ComparisonKind.NotEqual:
-                    return Comparison.NotEqual;
+                    return ComparisonFunction.NotEqual;
                 case ComparisonKind.GreaterEqual:
-                    return Comparison.GreaterEqual;
+                    return ComparisonFunction.GreaterEqual;
                 case ComparisonKind.Always:
-                    return Comparison.Always;
+                    return ComparisonFunction.Always;
                 default:
                     throw Illegal.Value<ComparisonKind>();
             }

--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -326,7 +326,7 @@ namespace Veldrid.D3D11
                                 resource,
                                 mode,
                                 msr.DataPointer,
-                                (uint)mipSize,
+                                texture.Height * (uint)msr.RowPitch,
                                 subresource,
                                 (uint)msr.RowPitch,
                                 (uint)msr.DepthPitch);

--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -77,7 +77,7 @@ namespace Veldrid.D3D11
                     Vortice.Direct3D11.D3D11.D3D11CreateDevice(_dxgiAdapter,
                         Vortice.Direct3D.DriverType.Hardware,
                         flags,
-                        new [] { Vortice.Direct3D.FeatureLevel.Level_11_1, },
+                        new [] { Vortice.Direct3D.FeatureLevel.Level_11_0, Vortice.Direct3D.FeatureLevel.Level_11_1, },
                         out _device).CheckError();
                 }
                 else
@@ -85,7 +85,7 @@ namespace Veldrid.D3D11
                     Vortice.Direct3D11.D3D11.D3D11CreateDevice(null,
                         Vortice.Direct3D.DriverType.Hardware,
                         flags,
-                        new[] { Vortice.Direct3D.FeatureLevel.Level_11_1, },
+                        new[] { Vortice.Direct3D.FeatureLevel.Level_11_0, Vortice.Direct3D.FeatureLevel.Level_11_1, },
                         out _device).CheckError();
                 }
             }

--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -77,7 +77,11 @@ namespace Veldrid.D3D11
                     Vortice.Direct3D11.D3D11.D3D11CreateDevice(_dxgiAdapter,
                         Vortice.Direct3D.DriverType.Hardware,
                         flags,
-                        new [] { Vortice.Direct3D.FeatureLevel.Level_11_0, Vortice.Direct3D.FeatureLevel.Level_11_1, },
+                        new[] 
+                        { 
+                            Vortice.Direct3D.FeatureLevel.Level_11_1, 
+                            Vortice.Direct3D.FeatureLevel.Level_11_0, 
+                        },
                         out _device).CheckError();
                 }
                 else
@@ -85,7 +89,11 @@ namespace Veldrid.D3D11
                     Vortice.Direct3D11.D3D11.D3D11CreateDevice(null,
                         Vortice.Direct3D.DriverType.Hardware,
                         flags,
-                        new[] { Vortice.Direct3D.FeatureLevel.Level_11_0, Vortice.Direct3D.FeatureLevel.Level_11_1, },
+                        new[] 
+                        { 
+                            Vortice.Direct3D.FeatureLevel.Level_11_1, 
+                            Vortice.Direct3D.FeatureLevel.Level_11_0, 
+                        },
                         out _device).CheckError();
                 }
             }

--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -420,7 +420,7 @@ namespace Veldrid.D3D11
                 }
                 else
                 {
-                    System.Buffer.MemoryCopy(
+                    Buffer.MemoryCopy(
                         source.ToPointer(),
                         (byte*)mr.Data + bufferOffsetInBytes,
                         buffer.SizeInBytes,
@@ -436,8 +436,8 @@ namespace Veldrid.D3D11
                 lock (_immediateContextLock)
                 {
                     _immediateContext.CopySubresourceRegion(
-                        staging.Buffer, 0, (int)bufferOffsetInBytes, 0, 0,
-                        d3dBuffer.Buffer, 0,
+                        d3dBuffer.Buffer, 0, (int)bufferOffsetInBytes, 0, 0,
+                        staging.Buffer, 0,
                         sourceRegion);
                 }
 

--- a/src/Veldrid/D3D11/D3D11Pipeline.cs
+++ b/src/Veldrid/D3D11/D3D11Pipeline.cs
@@ -1,4 +1,4 @@
-﻿using SharpDX.Direct3D11;
+﻿using Vortice.Direct3D11;
 using System.Diagnostics;
 using System;
 
@@ -9,18 +9,18 @@ namespace Veldrid.D3D11
         private string _name;
         private bool _disposed;
 
-        public BlendState BlendState { get; }
-        public DepthStencilState DepthStencilState { get; }
+        public ID3D11BlendState BlendState { get; }
+        public ID3D11DepthStencilState DepthStencilState { get; }
         public uint StencilReference { get; }
-        public RasterizerState RasterizerState { get; }
-        public SharpDX.Direct3D.PrimitiveTopology PrimitiveTopology { get; }
-        public InputLayout InputLayout { get; }
-        public VertexShader VertexShader { get; }
-        public GeometryShader GeometryShader { get; } // May be null.
-        public HullShader HullShader { get; } // May be null.
-        public DomainShader DomainShader { get; } // May be null.
-        public PixelShader PixelShader { get; }
-        public ComputeShader ComputeShader { get; }
+        public ID3D11RasterizerState RasterizerState { get; }
+        public Vortice.Direct3D.PrimitiveTopology PrimitiveTopology { get; }
+        public ID3D11InputLayout InputLayout { get; }
+        public ID3D11VertexShader VertexShader { get; }
+        public ID3D11GeometryShader GeometryShader { get; } // May be null.
+        public ID3D11HullShader HullShader { get; } // May be null.
+        public ID3D11DomainShader DomainShader { get; } // May be null.
+        public ID3D11PixelShader PixelShader { get; }
+        public ID3D11ComputeShader ComputeShader { get; }
         public new D3D11ResourceLayout[] ResourceLayouts { get; }
         public int[] VertexStrides { get; }
 
@@ -36,28 +36,28 @@ namespace Veldrid.D3D11
                 if (stages[i].Stage == ShaderStages.Vertex)
                 {
                     D3D11Shader d3d11VertexShader = ((D3D11Shader)stages[i]);
-                    VertexShader = (VertexShader)d3d11VertexShader.DeviceShader;
+                    VertexShader = (ID3D11VertexShader)d3d11VertexShader.DeviceShader;
                     vsBytecode = d3d11VertexShader.Bytecode;
                 }
                 if (stages[i].Stage == ShaderStages.Geometry)
                 {
-                    GeometryShader = (GeometryShader)((D3D11Shader)stages[i]).DeviceShader;
+                    GeometryShader = (ID3D11GeometryShader)((D3D11Shader)stages[i]).DeviceShader;
                 }
                 if (stages[i].Stage == ShaderStages.TessellationControl)
                 {
-                    HullShader = (HullShader)((D3D11Shader)stages[i]).DeviceShader;
+                    HullShader = (ID3D11HullShader)((D3D11Shader)stages[i]).DeviceShader;
                 }
                 if (stages[i].Stage == ShaderStages.TessellationEvaluation)
                 {
-                    DomainShader = (DomainShader)((D3D11Shader)stages[i]).DeviceShader;
+                    DomainShader = (ID3D11DomainShader)((D3D11Shader)stages[i]).DeviceShader;
                 }
                 if (stages[i].Stage == ShaderStages.Fragment)
                 {
-                    PixelShader = (PixelShader)((D3D11Shader)stages[i]).DeviceShader;
+                    PixelShader = (ID3D11PixelShader)((D3D11Shader)stages[i]).DeviceShader;
                 }
                 if (stages[i].Stage == ShaderStages.Compute)
                 {
-                    ComputeShader = (ComputeShader)((D3D11Shader)stages[i]).DeviceShader;
+                    ComputeShader = (ID3D11ComputeShader)((D3D11Shader)stages[i]).DeviceShader;
                 }
             }
 
@@ -68,10 +68,10 @@ namespace Veldrid.D3D11
                 description.Outputs.SampleCount != TextureSampleCount.Count1,
                 description.ShaderSet.VertexLayouts,
                 vsBytecode,
-                out BlendState blendState,
-                out DepthStencilState depthStencilState,
-                out RasterizerState rasterizerState,
-                out InputLayout inputLayout);
+                out ID3D11BlendState blendState,
+                out ID3D11DepthStencilState depthStencilState,
+                out ID3D11RasterizerState rasterizerState,
+                out ID3D11InputLayout inputLayout);
 
             BlendState = blendState;
             DepthStencilState = depthStencilState;
@@ -107,7 +107,7 @@ namespace Veldrid.D3D11
             : base(ref description)
         {
             IsComputePipeline = true;
-            ComputeShader = (ComputeShader)((D3D11Shader)description.ComputeShader).DeviceShader;
+            ComputeShader = (ID3D11ComputeShader)((D3D11Shader)description.ComputeShader).DeviceShader;
             ResourceLayout[] genericLayouts = description.ResourceLayouts;
             ResourceLayouts = new D3D11ResourceLayout[genericLayouts.Length];
             for (int i = 0; i < ResourceLayouts.Length; i++)

--- a/src/Veldrid/D3D11/D3D11ResourceCache.cs
+++ b/src/Veldrid/D3D11/D3D11ResourceCache.cs
@@ -1,29 +1,29 @@
-﻿using SharpDX.Direct3D11;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using Vortice.Direct3D11;
 
 namespace Veldrid.D3D11
 {
     internal class D3D11ResourceCache : IDisposable
     {
-        private readonly Device _device;
+        private readonly ID3D11Device _device;
         private readonly object _lock = new object();
 
-        private readonly Dictionary<BlendStateDescription, BlendState> _blendStates
-            = new Dictionary<BlendStateDescription, BlendState>();
+        private readonly Dictionary<BlendStateDescription, ID3D11BlendState> _blendStates
+            = new Dictionary<BlendStateDescription, ID3D11BlendState>();
 
-        private readonly Dictionary<DepthStencilStateDescription, DepthStencilState> _depthStencilStates
-            = new Dictionary<DepthStencilStateDescription, DepthStencilState>();
+        private readonly Dictionary<DepthStencilStateDescription, ID3D11DepthStencilState> _depthStencilStates
+            = new Dictionary<DepthStencilStateDescription, ID3D11DepthStencilState>();
 
-        private readonly Dictionary<D3D11RasterizerStateCacheKey, RasterizerState> _rasterizerStates
-            = new Dictionary<D3D11RasterizerStateCacheKey, RasterizerState>();
+        private readonly Dictionary<D3D11RasterizerStateCacheKey, ID3D11RasterizerState> _rasterizerStates
+            = new Dictionary<D3D11RasterizerStateCacheKey, ID3D11RasterizerState>();
 
-        private readonly Dictionary<InputLayoutCacheKey, InputLayout> _inputLayouts
-            = new Dictionary<InputLayoutCacheKey, InputLayout>();
+        private readonly Dictionary<InputLayoutCacheKey, ID3D11InputLayout> _inputLayouts
+            = new Dictionary<InputLayoutCacheKey, ID3D11InputLayout>();
 
-        public D3D11ResourceCache(Device device)
+        public D3D11ResourceCache(ID3D11Device device)
         {
             _device = device;
         }
@@ -35,10 +35,10 @@ namespace Veldrid.D3D11
             bool multisample,
             VertexLayoutDescription[] vertexLayouts,
             byte[] vsBytecode,
-            out BlendState blendState,
-            out DepthStencilState depthState,
-            out RasterizerState rasterState,
-            out InputLayout inputLayout)
+            out ID3D11BlendState blendState,
+            out ID3D11DepthStencilState depthState,
+            out ID3D11RasterizerState rasterState,
+            out ID3D11InputLayout inputLayout)
         {
             lock (_lock)
             {
@@ -49,10 +49,10 @@ namespace Veldrid.D3D11
             }
         }
 
-        private BlendState GetBlendState(ref BlendStateDescription description)
+        private ID3D11BlendState GetBlendState(ref BlendStateDescription description)
         {
             Debug.Assert(Monitor.IsEntered(_lock));
-            if (!_blendStates.TryGetValue(description, out BlendState blendState))
+            if (!_blendStates.TryGetValue(description, out ID3D11BlendState blendState))
             {
                 blendState = CreateNewBlendState(ref description);
                 BlendStateDescription key = description;
@@ -63,33 +63,33 @@ namespace Veldrid.D3D11
             return blendState;
         }
 
-        private BlendState CreateNewBlendState(ref BlendStateDescription description)
+        private ID3D11BlendState CreateNewBlendState(ref BlendStateDescription description)
         {
             BlendAttachmentDescription[] attachmentStates = description.AttachmentStates;
-            SharpDX.Direct3D11.BlendStateDescription d3dBlendStateDesc = new SharpDX.Direct3D11.BlendStateDescription();
+            Vortice.Direct3D11.BlendDescription d3dBlendStateDesc = new Vortice.Direct3D11.BlendDescription();
 
             for (int i = 0; i < attachmentStates.Length; i++)
             {
                 BlendAttachmentDescription state = attachmentStates[i];
                 d3dBlendStateDesc.RenderTarget[i].IsBlendEnabled = state.BlendEnabled;
-                d3dBlendStateDesc.RenderTarget[i].RenderTargetWriteMask = ColorWriteMaskFlags.All;
-                d3dBlendStateDesc.RenderTarget[i].SourceBlend = D3D11Formats.VdToD3D11BlendOption(state.SourceColorFactor);
-                d3dBlendStateDesc.RenderTarget[i].DestinationBlend = D3D11Formats.VdToD3D11BlendOption(state.DestinationColorFactor);
+                d3dBlendStateDesc.RenderTarget[i].RenderTargetWriteMask = ColorWriteEnable.All;
+                d3dBlendStateDesc.RenderTarget[i].SourceBlend = D3D11Formats.VdToD3D11Blend(state.SourceColorFactor);
+                d3dBlendStateDesc.RenderTarget[i].DestinationBlend = D3D11Formats.VdToD3D11Blend(state.DestinationColorFactor);
                 d3dBlendStateDesc.RenderTarget[i].BlendOperation = D3D11Formats.VdToD3D11BlendOperation(state.ColorFunction);
-                d3dBlendStateDesc.RenderTarget[i].SourceAlphaBlend = D3D11Formats.VdToD3D11BlendOption(state.SourceAlphaFactor);
-                d3dBlendStateDesc.RenderTarget[i].DestinationAlphaBlend = D3D11Formats.VdToD3D11BlendOption(state.DestinationAlphaFactor);
-                d3dBlendStateDesc.RenderTarget[i].AlphaBlendOperation = D3D11Formats.VdToD3D11BlendOperation(state.AlphaFunction);
+                d3dBlendStateDesc.RenderTarget[i].SourceBlendAlpha = D3D11Formats.VdToD3D11Blend(state.SourceAlphaFactor);
+                d3dBlendStateDesc.RenderTarget[i].DestinationBlendAlpha = D3D11Formats.VdToD3D11Blend(state.DestinationAlphaFactor);
+                d3dBlendStateDesc.RenderTarget[i].BlendOperationAlpha = D3D11Formats.VdToD3D11BlendOperation(state.AlphaFunction);
             }
 
             d3dBlendStateDesc.AlphaToCoverageEnable = description.AlphaToCoverageEnabled;
 
-            return new BlendState(_device, d3dBlendStateDesc);
+            return _device.CreateBlendState(d3dBlendStateDesc);
         }
 
-        private DepthStencilState GetDepthStencilState(ref DepthStencilStateDescription description)
+        private ID3D11DepthStencilState GetDepthStencilState(ref DepthStencilStateDescription description)
         {
             Debug.Assert(Monitor.IsEntered(_lock));
-            if (!_depthStencilStates.TryGetValue(description, out DepthStencilState dss))
+            if (!_depthStencilStates.TryGetValue(description, out ID3D11DepthStencilState dss))
             {
                 dss = CreateNewDepthStencilState(ref description);
                 DepthStencilStateDescription key = description;
@@ -99,39 +99,39 @@ namespace Veldrid.D3D11
             return dss;
         }
 
-        private DepthStencilState CreateNewDepthStencilState(ref DepthStencilStateDescription description)
+        private ID3D11DepthStencilState CreateNewDepthStencilState(ref DepthStencilStateDescription description)
         {
-            SharpDX.Direct3D11.DepthStencilStateDescription dssDesc = new SharpDX.Direct3D11.DepthStencilStateDescription
+            DepthStencilDescription dssDesc = new DepthStencilDescription
             {
-                DepthComparison = D3D11Formats.VdToD3D11Comparison(description.DepthComparison),
-                IsDepthEnabled = description.DepthTestEnabled,
+                DepthFunc = D3D11Formats.VdToD3D11ComparisonFunc(description.DepthComparison),
+                DepthEnable = description.DepthTestEnabled,
                 DepthWriteMask = description.DepthWriteEnabled ? DepthWriteMask.All : DepthWriteMask.Zero,
-                IsStencilEnabled = description.StencilTestEnabled,
+                StencilEnable = description.StencilTestEnabled,
                 FrontFace = ToD3D11StencilOpDesc(description.StencilFront),
                 BackFace = ToD3D11StencilOpDesc(description.StencilBack),
                 StencilReadMask = description.StencilReadMask,
                 StencilWriteMask = description.StencilWriteMask
             };
 
-            return new DepthStencilState(_device, dssDesc);
+            return _device.CreateDepthStencilState(dssDesc);
         }
 
         private DepthStencilOperationDescription ToD3D11StencilOpDesc(StencilBehaviorDescription sbd)
         {
             return new DepthStencilOperationDescription
             {
-                Comparison = D3D11Formats.VdToD3D11Comparison(sbd.Comparison),
-                PassOperation = D3D11Formats.VdToD3D11StencilOperation(sbd.Pass),
-                FailOperation = D3D11Formats.VdToD3D11StencilOperation(sbd.Fail),
-                DepthFailOperation = D3D11Formats.VdToD3D11StencilOperation(sbd.DepthFail)
+                StencilFunc = D3D11Formats.VdToD3D11ComparisonFunc(sbd.Comparison),
+                StencilPassOp = D3D11Formats.VdToD3D11StencilOperation(sbd.Pass),
+                StencilFailOp = D3D11Formats.VdToD3D11StencilOperation(sbd.Fail),
+                StencilDepthFailOp = D3D11Formats.VdToD3D11StencilOperation(sbd.DepthFail)
             };
         }
 
-        private RasterizerState GetRasterizerState(ref RasterizerStateDescription description, bool multisample)
+        private ID3D11RasterizerState GetRasterizerState(ref RasterizerStateDescription description, bool multisample)
         {
             Debug.Assert(Monitor.IsEntered(_lock));
             D3D11RasterizerStateCacheKey key = new D3D11RasterizerStateCacheKey(description, multisample);
-            if (!_rasterizerStates.TryGetValue(key, out RasterizerState rasterizerState))
+            if (!_rasterizerStates.TryGetValue(key, out ID3D11RasterizerState rasterizerState))
             {
                 rasterizerState = CreateNewRasterizerState(ref key);
                 _rasterizerStates.Add(key, rasterizerState);
@@ -140,29 +140,29 @@ namespace Veldrid.D3D11
             return rasterizerState;
         }
 
-        private RasterizerState CreateNewRasterizerState(ref D3D11RasterizerStateCacheKey key)
+        private ID3D11RasterizerState CreateNewRasterizerState(ref D3D11RasterizerStateCacheKey key)
         {
-            SharpDX.Direct3D11.RasterizerStateDescription rssDesc = new SharpDX.Direct3D11.RasterizerStateDescription
+            RasterizerDescription rssDesc = new RasterizerDescription
             {
                 CullMode = D3D11Formats.VdToD3D11CullMode(key.VeldridDescription.CullMode),
                 FillMode = D3D11Formats.VdToD3D11FillMode(key.VeldridDescription.FillMode),
-                IsDepthClipEnabled = key.VeldridDescription.DepthClipEnabled,
-                IsScissorEnabled = key.VeldridDescription.ScissorTestEnabled,
-                IsFrontCounterClockwise = key.VeldridDescription.FrontFace == FrontFace.CounterClockwise,
-                IsMultisampleEnabled = key.Multisampled
+                DepthClipEnable = key.VeldridDescription.DepthClipEnabled,
+                ScissorEnable = key.VeldridDescription.ScissorTestEnabled,
+                FrontCounterClockwise = key.VeldridDescription.FrontFace == FrontFace.CounterClockwise,
+                MultisampleEnable = key.Multisampled
             };
 
-            return new RasterizerState(_device, rssDesc);
+            return _device.CreateRasterizerState(rssDesc);
         }
 
-        private InputLayout GetInputLayout(VertexLayoutDescription[] vertexLayouts, byte[] vsBytecode)
+        private ID3D11InputLayout GetInputLayout(VertexLayoutDescription[] vertexLayouts, byte[] vsBytecode)
         {
             Debug.Assert(Monitor.IsEntered(_lock));
 
             if (vsBytecode == null || vertexLayouts == null || vertexLayouts.Length == 0) { return null; }
 
             InputLayoutCacheKey tempKey = InputLayoutCacheKey.CreateTempKey(vertexLayouts);
-            if (!_inputLayouts.TryGetValue(tempKey, out InputLayout inputLayout))
+            if (!_inputLayouts.TryGetValue(tempKey, out ID3D11InputLayout inputLayout))
             {
                 inputLayout = CreateNewInputLayout(vertexLayouts, vsBytecode);
                 InputLayoutCacheKey permanentKey = InputLayoutCacheKey.CreatePermanentKey(vertexLayouts);
@@ -172,7 +172,7 @@ namespace Veldrid.D3D11
             return inputLayout;
         }
 
-        private InputLayout CreateNewInputLayout(VertexLayoutDescription[] vertexLayouts, byte[] vsBytecode)
+        private ID3D11InputLayout CreateNewInputLayout(VertexLayoutDescription[] vertexLayouts, byte[] vsBytecode)
         {
             int totalCount = 0;
             for (int i = 0; i < vertexLayouts.Length; i++)
@@ -181,7 +181,7 @@ namespace Veldrid.D3D11
             }
 
             int element = 0; // Total element index across slots.
-            InputElement[] elements = new InputElement[totalCount];
+            InputElementDescription[] elements = new InputElementDescription[totalCount];
             SemanticIndices si = new SemanticIndices();
             for (int slot = 0; slot < vertexLayouts.Length; slot++)
             {
@@ -191,7 +191,7 @@ namespace Veldrid.D3D11
                 for (int i = 0; i < elementDescs.Length; i++)
                 {
                     VertexElementDescription desc = elementDescs[i];
-                    elements[element] = new InputElement(
+                    elements[element] = new InputElementDescription(
                         GetSemanticString(desc.Semantic),
                         SemanticIndices.GetAndIncrement(ref si, desc.Semantic),
                         D3D11Formats.ToDxgiFormat(desc.Format),
@@ -205,7 +205,7 @@ namespace Veldrid.D3D11
                 }
             }
 
-            return new InputLayout(_device, vsBytecode, elements);
+            return _device.CreateInputLayout(elements, vsBytecode);
         }
 
         private string GetSemanticString(VertexElementSemantic semantic)
@@ -227,19 +227,19 @@ namespace Veldrid.D3D11
 
         public void Dispose()
         {
-            foreach (KeyValuePair<BlendStateDescription, BlendState> kvp in _blendStates)
+            foreach (KeyValuePair<BlendStateDescription, ID3D11BlendState> kvp in _blendStates)
             {
                 kvp.Value.Dispose();
             }
-            foreach (KeyValuePair<DepthStencilStateDescription, DepthStencilState> kvp in _depthStencilStates)
+            foreach (KeyValuePair<DepthStencilStateDescription, ID3D11DepthStencilState> kvp in _depthStencilStates)
             {
                 kvp.Value.Dispose();
             }
-            foreach (KeyValuePair<D3D11RasterizerStateCacheKey, RasterizerState> kvp in _rasterizerStates)
+            foreach (KeyValuePair<D3D11RasterizerStateCacheKey, ID3D11RasterizerState> kvp in _rasterizerStates)
             {
                 kvp.Value.Dispose();
             }
-            foreach (KeyValuePair<InputLayoutCacheKey, InputLayout> kvp in _inputLayouts)
+            foreach (KeyValuePair<InputLayoutCacheKey, ID3D11InputLayout> kvp in _inputLayouts)
             {
                 kvp.Value.Dispose();
             }

--- a/src/Veldrid/D3D11/D3D11ResourceFactory.cs
+++ b/src/Veldrid/D3D11/D3D11ResourceFactory.cs
@@ -1,4 +1,4 @@
-﻿using SharpDX.Direct3D11;
+﻿using Vortice.Direct3D11;
 using System;
 
 namespace Veldrid.D3D11
@@ -6,7 +6,7 @@ namespace Veldrid.D3D11
     internal class D3D11ResourceFactory : ResourceFactory, IDisposable
     {
         private readonly D3D11GraphicsDevice _gd;
-        private readonly Device _device;
+        private readonly ID3D11Device _device;
         private readonly D3D11ResourceCache _cache;
 
         public override GraphicsBackend BackendType => GraphicsBackend.Direct3D11;
@@ -67,7 +67,7 @@ namespace Veldrid.D3D11
 
         protected override Texture CreateTextureCore(ulong nativeTexture, ref TextureDescription description)
         {
-            Texture2D existingTexture = new Texture2D((IntPtr)nativeTexture);
+            ID3D11Texture2D existingTexture = new ID3D11Texture2D((IntPtr)nativeTexture);
             return new D3D11Texture(existingTexture, description.Type, description.Format);
         }
 

--- a/src/Veldrid/D3D11/D3D11Sampler.cs
+++ b/src/Veldrid/D3D11/D3D11Sampler.cs
@@ -1,5 +1,5 @@
-﻿using SharpDX.Direct3D11;
-using SharpDX.Mathematics.Interop;
+﻿using Vortice.Direct3D11;
+using Vortice.Mathematics;
 
 namespace Veldrid.D3D11
 {
@@ -7,38 +7,38 @@ namespace Veldrid.D3D11
     {
         private string _name;
 
-        public SamplerState DeviceSampler { get; }
+        public ID3D11SamplerState DeviceSampler { get; }
 
-        public D3D11Sampler(Device device, ref SamplerDescription description)
+        public D3D11Sampler(ID3D11Device device, ref SamplerDescription description)
         {
-            Comparison comparision = description.ComparisonKind == null ? Comparison.Never : D3D11Formats.VdToD3D11Comparison(description.ComparisonKind.Value);
-            SamplerStateDescription samplerStateDesc = new SamplerStateDescription
+            ComparisonFunction comparision = description.ComparisonKind == null ? ComparisonFunction.Never : D3D11Formats.VdToD3D11ComparisonFunc(description.ComparisonKind.Value);
+            Vortice.Direct3D11.SamplerDescription samplerStateDesc = new Vortice.Direct3D11.SamplerDescription
             {
                 AddressU = D3D11Formats.VdToD3D11AddressMode(description.AddressModeU),
                 AddressV = D3D11Formats.VdToD3D11AddressMode(description.AddressModeV),
                 AddressW = D3D11Formats.VdToD3D11AddressMode(description.AddressModeW),
                 Filter = D3D11Formats.ToD3D11Filter(description.Filter, description.ComparisonKind.HasValue),
-                MinimumLod = description.MinimumLod,
-                MaximumLod = description.MaximumLod,
-                MaximumAnisotropy = (int)description.MaximumAnisotropy,
+                MinLOD = description.MinimumLod,
+                MaxLOD = description.MaximumLod,
+                MaxAnisotropy = (int)description.MaximumAnisotropy,
                 ComparisonFunction = comparision,
-                MipLodBias = description.LodBias,
+                MipLODBias = description.LodBias,
                 BorderColor = ToRawColor4(description.BorderColor)
             };
 
-            DeviceSampler = new SamplerState(device, samplerStateDesc);
+            DeviceSampler = device.CreateSamplerState(samplerStateDesc);
         }
 
-        private static RawColor4 ToRawColor4(SamplerBorderColor borderColor)
+        private static Color4 ToRawColor4(SamplerBorderColor borderColor)
         {
             switch (borderColor)
             {
                 case SamplerBorderColor.TransparentBlack:
-                    return new RawColor4(0, 0, 0, 0);
+                    return new Color4(0, 0, 0, 0);
                 case SamplerBorderColor.OpaqueBlack:
-                    return new RawColor4(0, 0, 0, 1);
+                    return new Color4(0, 0, 0, 1);
                 case SamplerBorderColor.OpaqueWhite:
-                    return new RawColor4(1, 1, 1, 1);
+                    return new Color4(1, 1, 1, 1);
                 default:
                     throw Illegal.Value<SamplerBorderColor>();
             }

--- a/src/Veldrid/D3D11/D3D11Shader.cs
+++ b/src/Veldrid/D3D11/D3D11Shader.cs
@@ -82,26 +82,9 @@ namespace Veldrid.D3D11
             }
 
             ShaderFlags flags = description.Debug ? ShaderFlags.Debug : ShaderFlags.OptimizationLevel3;
-            Blob result = null, error = null;
-
-            unsafe
-            {
-                fixed (byte* pArr = description.ShaderBytes)
-                {
-                    Compiler.Compile(
-                        (IntPtr)pArr,
-                        description.ShaderBytes.Length,
-                        null, null, null,
-                        description.EntryPoint, profile,
-                        flags,
-                        EffectFlags.None,
-                        out result,
-                        out error
-                        );
-
-                }
-            }
-
+            Compiler.Compile(description.ShaderBytes,
+                             description.EntryPoint, null,
+                             profile, out Blob result, out Blob error);
 
             if (result == null)
             {

--- a/src/Veldrid/D3D11/D3D11Shader.cs
+++ b/src/Veldrid/D3D11/D3D11Shader.cs
@@ -1,6 +1,8 @@
 ﻿using System;
-using SharpDX.D3DCompiler;
-using SharpDX.Direct3D11;
+using System.Text;
+using Vortice.D3DCompiler;
+using Vortice.Direct3D;
+using Vortice.Direct3D11;
 
 namespace Veldrid.D3D11
 {
@@ -8,10 +10,10 @@ namespace Veldrid.D3D11
     {
         private string _name;
 
-        public DeviceChild DeviceShader { get; }
+        public ID3D11DeviceChild DeviceShader { get; }
         public byte[] Bytecode { get; internal set; }
 
-        public D3D11Shader(Device device, ShaderDescription description)
+        public D3D11Shader(ID3D11Device device, ShaderDescription description)
             : base(description.Stage, description.EntryPoint)
         {
             if (description.ShaderBytes.Length > 4
@@ -30,22 +32,22 @@ namespace Veldrid.D3D11
             switch (description.Stage)
             {
                 case ShaderStages.Vertex:
-                    DeviceShader = new VertexShader(device, Bytecode);
+                    DeviceShader = device.CreateVertexShader(Bytecode);
                     break;
                 case ShaderStages.Geometry:
-                    DeviceShader = new GeometryShader(device, Bytecode);
+                    DeviceShader = device.CreateGeometryShader(Bytecode);
                     break;
                 case ShaderStages.TessellationControl:
-                    DeviceShader = new HullShader(device, Bytecode);
+                    DeviceShader = device.CreateHullShader(Bytecode);
                     break;
                 case ShaderStages.TessellationEvaluation:
-                    DeviceShader = new DomainShader(device, Bytecode);
+                    DeviceShader = device.CreateDomainShader(Bytecode);
                     break;
                 case ShaderStages.Fragment:
-                    DeviceShader = new PixelShader(device, Bytecode);
+                    DeviceShader = device.CreatePixelShader(Bytecode);
                     break;
                 case ShaderStages.Compute:
-                    DeviceShader = new ComputeShader(device, Bytecode);
+                    DeviceShader = device.CreateComputeShader(Bytecode);
                     break;
                 default:
                     throw Illegal.Value<ShaderStages>();
@@ -80,18 +82,33 @@ namespace Veldrid.D3D11
             }
 
             ShaderFlags flags = description.Debug ? ShaderFlags.Debug : ShaderFlags.OptimizationLevel3;
-            CompilationResult result = ShaderBytecode.Compile(
-                description.ShaderBytes,
-                description.EntryPoint,
-                profile,
-                flags);
+            Blob result = null, error = null;
 
-            if (result.ResultCode.Failure)
+            unsafe
             {
-                throw new VeldridException($"Failed to compile HLSL code: {result.Message}");
+                fixed (byte* pArr = description.ShaderBytes)
+                {
+                    Compiler.Compile(
+                        (IntPtr)pArr,
+                        description.ShaderBytes.Length,
+                        null, null, null,
+                        description.EntryPoint, profile,
+                        flags,
+                        EffectFlags.None,
+                        out result,
+                        out error
+                        );
+
+                }
             }
 
-            return result.Bytecode.Data;
+
+            if (result == null)
+            {
+                throw new VeldridException($"Failed to compile HLSL code: {Encoding.ASCII.GetString(error.GetBytes())}");
+            }
+
+            return result.GetBytes();
         }
 
         public override string Name

--- a/src/Veldrid/D3D11/D3D11Swapchain.cs
+++ b/src/Veldrid/D3D11/D3D11Swapchain.cs
@@ -118,10 +118,10 @@ namespace Veldrid.D3D11
                     Usage = Vortice.DXGI.Usage.Backbuffer | Vortice.DXGI.Usage.RenderTargetOutput,
                 };
 
-                // Retrive the SharpDX.DXGI device associated to the Direct3D device.
+                // Retrive the Vortice.DXGI device associated to the Direct3D device.
                 using (IDXGIDevice3 dxgiDevice = _device.QueryInterface<IDXGIDevice3>())
                 {
-                    // Get the SharpDX.DXGI factory automatically created when initializing the Direct3D device.
+                    // Get the Vortice.DXGI factory automatically created when initializing the Direct3D device.
                     using (IDXGIFactory2 dxgiFactory = dxgiDevice.Adapter.GetParent<IDXGIFactory2>())
                     {
                         // Create the swap chain and get the highest version available.

--- a/src/Veldrid/D3D11/D3D11Swapchain.cs
+++ b/src/Veldrid/D3D11/D3D11Swapchain.cs
@@ -134,19 +134,19 @@ namespace Veldrid.D3D11
 
                 ComObject co = new ComObject(uwpSource.SwapChainPanelNative);
 
-                //ISwapChainPanelNative swapchainPanelNative = co.QueryInterfaceOrNull<Vortice.DXGI.SwapC ISwapChainPanelNative>();
-                //if (swapchainPanelNative != null)
-                //{
-                //    swapchainPanelNative.SwapChain = _dxgiSwapChain;
-                //}
-                //else
-                //{
-                //    ISwapChainBackgroundPanelNative bgPanelNative = co.QueryInterfaceOrNull<ISwapChainBackgroundPanelNative>();
-                //    if (bgPanelNative != null)
-                //    {
-                //        bgPanelNative.SwapChain = _dxgiSwapChain;
-                //    }
-                //}
+                ISwapChainPanelNative swapchainPanelNative = co.QueryInterfaceOrNull<ISwapChainPanelNative>();
+                if (swapchainPanelNative != null)
+                {
+                    swapchainPanelNative.SetSwapChain(_dxgiSwapChain);
+                }
+                else
+                {
+                    ISwapChainBackgroundPanelNative bgPanelNative = co.QueryInterfaceOrNull<ISwapChainBackgroundPanelNative>();
+                    if (bgPanelNative != null)
+                    {
+                        bgPanelNative.SetSwapChain(_dxgiSwapChain);
+                    }
+                }
             }
 
             Resize(description.Width, description.Height);

--- a/src/Veldrid/D3D11/D3D11Texture.cs
+++ b/src/Veldrid/D3D11/D3D11Texture.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Diagnostics;
-using SharpDX.Direct3D11;
+using Vortice.Direct3D11;
 
 namespace Veldrid.D3D11
 {
     internal class D3D11Texture : Texture
     {
-        private readonly Device _device;
+        private readonly ID3D11Device _device;
         private string _name;
 
         public override uint Width { get; }
@@ -20,11 +20,11 @@ namespace Veldrid.D3D11
         public override TextureSampleCount SampleCount { get; }
         public override bool IsDisposed => DeviceTexture.IsDisposed;
 
-        public Resource DeviceTexture { get; }
-        public SharpDX.DXGI.Format DxgiFormat { get; }
-        public SharpDX.DXGI.Format TypelessDxgiFormat { get; }
+        public ID3D11Resource DeviceTexture { get; }
+        public Vortice.DXGI.Format DxgiFormat { get; }
+        public Vortice.DXGI.Format TypelessDxgiFormat { get; }
 
-        public D3D11Texture(Device device, ref TextureDescription description)
+        public D3D11Texture(ID3D11Device device, ref TextureDescription description)
         {
             _device = device;
             Width = description.Width;
@@ -43,7 +43,7 @@ namespace Veldrid.D3D11
             TypelessDxgiFormat = D3D11Formats.GetTypelessFormat(DxgiFormat);
 
             CpuAccessFlags cpuFlags = CpuAccessFlags.None;
-            ResourceUsage resourceUsage = ResourceUsage.Default;
+            Usage resourceUsage = Vortice.Direct3D11.Usage.Default;
             BindFlags bindFlags = BindFlags.None;
             ResourceOptionFlags optionFlags = ResourceOptionFlags.None;
 
@@ -66,13 +66,13 @@ namespace Veldrid.D3D11
             if ((description.Usage & TextureUsage.Staging) == TextureUsage.Staging)
             {
                 cpuFlags = CpuAccessFlags.Read | CpuAccessFlags.Write;
-                resourceUsage = ResourceUsage.Staging;
+                resourceUsage = Vortice.Direct3D11.Usage.Staging;
             }
 
             if ((description.Usage & TextureUsage.GenerateMipmaps) != 0)
             {
                 bindFlags |= BindFlags.RenderTarget | BindFlags.ShaderResource;
-                optionFlags |= ResourceOptionFlags.GenerateMipMaps;
+                optionFlags |= ResourceOptionFlags.GenerateMips;
             }
 
             int arraySize = (int)description.ArrayLayers;
@@ -104,7 +104,7 @@ namespace Veldrid.D3D11
                     OptionFlags = optionFlags,
                 };
 
-                DeviceTexture = new Texture1D(device, desc1D);
+                DeviceTexture = device.CreateTexture1D(desc1D);
             }
             else if (Type == TextureType.Texture2D)
             {
@@ -118,11 +118,11 @@ namespace Veldrid.D3D11
                     BindFlags = bindFlags,
                     CpuAccessFlags = cpuFlags,
                     Usage = resourceUsage,
-                    SampleDescription = new SharpDX.DXGI.SampleDescription((int)FormatHelpers.GetSampleCountUInt32(SampleCount), 0),
+                    SampleDescription = new Vortice.DXGI.SampleDescription((int)FormatHelpers.GetSampleCountUInt32(SampleCount), 0),
                     OptionFlags = optionFlags,
                 };
 
-                DeviceTexture = new Texture2D(device, deviceDescription);
+                DeviceTexture = device.CreateTexture2D(deviceDescription);
             }
             else
             {
@@ -140,11 +140,11 @@ namespace Veldrid.D3D11
                     OptionFlags = optionFlags,
                 };
 
-                DeviceTexture = new Texture3D(device, desc3D);
+                DeviceTexture = device.CreateTexture3D(desc3D);
             }
         }
 
-        public D3D11Texture(Texture2D existingTexture, TextureType type, PixelFormat format)
+        public D3D11Texture(ID3D11Texture2D existingTexture, TextureType type, PixelFormat format)
         {
             _device = existingTexture.Device;
             DeviceTexture = existingTexture;

--- a/src/Veldrid/D3D11/D3D11TextureView.cs
+++ b/src/Veldrid/D3D11/D3D11TextureView.cs
@@ -1,4 +1,4 @@
-﻿using SharpDX.Direct3D11;
+﻿using Vortice.Direct3D11;
 using System;
 
 namespace Veldrid.D3D11
@@ -8,13 +8,13 @@ namespace Veldrid.D3D11
         private string _name;
         private bool _disposed;
 
-        public ShaderResourceView ShaderResourceView { get; }
-        public UnorderedAccessView UnorderedAccessView { get; }
+        public ID3D11ShaderResourceView ShaderResourceView { get; }
+        public ID3D11UnorderedAccessView UnorderedAccessView { get; }
 
         public D3D11TextureView(D3D11GraphicsDevice gd, ref TextureViewDescription description)
             : base(ref description)
         {
-            Device device = gd.Device;
+            ID3D11Device device = gd.Device;
             D3D11Texture d3dTex = Util.AssertSubtype<Texture, D3D11Texture>(description.Target);
             ShaderResourceViewDescription srvDesc = D3D11Util.GetSrvDesc(
                 d3dTex,
@@ -23,7 +23,7 @@ namespace Veldrid.D3D11
                 description.BaseArrayLayer,
                 description.ArrayLayers,
                 Format);
-            ShaderResourceView = new ShaderResourceView(device, d3dTex.DeviceTexture, srvDesc);
+            ShaderResourceView = device.CreateShaderResourceView(d3dTex.DeviceTexture, srvDesc);
 
             if ((d3dTex.Usage & TextureUsage.Storage) == TextureUsage.Storage)
             {
@@ -40,12 +40,12 @@ namespace Veldrid.D3D11
                     {
                         if (d3dTex.Type == TextureType.Texture1D)
                         {
-                            uavDesc.Dimension = UnorderedAccessViewDimension.Texture1D;
+                            uavDesc.ViewDimension = UnorderedAccessViewDimension.Texture1D;
                             uavDesc.Texture1D.MipSlice = (int)description.BaseMipLevel;
                         }
                         else
                         {
-                            uavDesc.Dimension = UnorderedAccessViewDimension.Texture2D;
+                            uavDesc.ViewDimension = UnorderedAccessViewDimension.Texture2D;
                             uavDesc.Texture2D.MipSlice = (int)description.BaseMipLevel;
                         }
                     }
@@ -53,14 +53,14 @@ namespace Veldrid.D3D11
                     {
                         if (d3dTex.Type == TextureType.Texture1D)
                         {
-                            uavDesc.Dimension = UnorderedAccessViewDimension.Texture1DArray;
+                            uavDesc.ViewDimension = UnorderedAccessViewDimension.Texture1DArray;
                             uavDesc.Texture1DArray.MipSlice = (int)description.BaseMipLevel;
                             uavDesc.Texture1DArray.FirstArraySlice = (int)description.BaseArrayLayer;
                             uavDesc.Texture1DArray.ArraySize = (int)description.ArrayLayers;
                         }
                         else
                         {
-                            uavDesc.Dimension = UnorderedAccessViewDimension.Texture2DArray;
+                            uavDesc.ViewDimension = UnorderedAccessViewDimension.Texture2DArray;
                             uavDesc.Texture2DArray.MipSlice = (int)description.BaseMipLevel;
                             uavDesc.Texture2DArray.FirstArraySlice = (int)description.BaseArrayLayer;
                             uavDesc.Texture2DArray.ArraySize = (int)description.ArrayLayers;
@@ -69,13 +69,13 @@ namespace Veldrid.D3D11
                 }
                 else
                 {
-                    uavDesc.Dimension = UnorderedAccessViewDimension.Texture3D;
+                    uavDesc.ViewDimension = UnorderedAccessViewDimension.Texture3D;
                     uavDesc.Texture3D.MipSlice = (int)description.BaseMipLevel;
                     uavDesc.Texture3D.FirstWSlice = (int)description.BaseArrayLayer;
                     uavDesc.Texture3D.WSize = (int)description.ArrayLayers;
                 }
 
-                UnorderedAccessView = new UnorderedAccessView(device, d3dTex.DeviceTexture, uavDesc);
+                UnorderedAccessView = device.CreateUnorderedAccessView(d3dTex.DeviceTexture, uavDesc);
             }
         }
 

--- a/src/Veldrid/D3D11/D3D11Util.cs
+++ b/src/Veldrid/D3D11/D3D11Util.cs
@@ -1,4 +1,5 @@
-﻿using Vortice.Direct3D11;
+﻿using System;
+using Vortice.Direct3D11;
 
 namespace Veldrid.D3D11
 {
@@ -86,6 +87,28 @@ namespace Veldrid.D3D11
             }
 
             return srvDesc;
+        }
+
+        internal static void SetUnorderedAccessViewsKeepRTV(this ID3D11DeviceContext context, int startSlot, int numBuffers, IntPtr unorderedAccessBuffer, IntPtr uavCount)
+        {
+            context.OMSetRenderTargetsAndUnorderedAccessViews(
+                ID3D11DeviceContext.KeepRenderTargetsAndDepthStencil,
+                IntPtr.Zero, null, startSlot, numBuffers,
+                unorderedAccessBuffer, uavCount);
+        }
+
+        internal static unsafe void SetUnorderedAccessViews(this ID3D11DeviceContext context, int startSlot, ID3D11UnorderedAccessView[] unorderedAccessViews, int[] uavInitialCounts)
+        {
+            IntPtr* unorderedAccessViewsOut_ = (IntPtr*)0;
+            if (unorderedAccessViews != null)
+            {
+                IntPtr* unorderedAccessViewsOut__ = stackalloc IntPtr[unorderedAccessViews.Length];
+                unorderedAccessViewsOut_ = unorderedAccessViewsOut__;
+                for (int i = 0; i < unorderedAccessViews.Length; i++)
+                    unorderedAccessViewsOut_[i] = (unorderedAccessViews[i] == null) ? IntPtr.Zero : unorderedAccessViews[i].NativePointer;
+            }
+            fixed (void* puav = uavInitialCounts)
+                context.SetUnorderedAccessViewsKeepRTV(startSlot, unorderedAccessViews != null ? unorderedAccessViews.Length : 0, (IntPtr)unorderedAccessViewsOut_, (IntPtr)puav);
         }
     }
 }

--- a/src/Veldrid/D3D11/D3D11Util.cs
+++ b/src/Veldrid/D3D11/D3D11Util.cs
@@ -1,4 +1,4 @@
-﻿using SharpDX.Direct3D11;
+﻿using Vortice.Direct3D11;
 
 namespace Veldrid.D3D11
 {
@@ -25,17 +25,17 @@ namespace Veldrid.D3D11
             {
                 if (tex.ArrayLayers == 1)
                 {
-                    srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.TextureCube;
+                    srvDesc.ViewDimension = Vortice.Direct3D.ShaderResourceViewDimension.TextureCube;
                     srvDesc.TextureCube.MostDetailedMip = (int)baseMipLevel;
                     srvDesc.TextureCube.MipLevels = (int)levelCount;
                 }
                 else
                 {
-                    srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.TextureCubeArray;
+                    srvDesc.ViewDimension = Vortice.Direct3D.ShaderResourceViewDimension.TextureCubeArray;
                     srvDesc.TextureCubeArray.MostDetailedMip = (int)baseMipLevel;
                     srvDesc.TextureCubeArray.MipLevels = (int)levelCount;
                     srvDesc.TextureCubeArray.First2DArrayFace = (int)baseArrayLayer;
-                    srvDesc.TextureCubeArray.CubeCount = (int)tex.ArrayLayers;
+                    srvDesc.TextureCubeArray.NumCubes = (int)tex.ArrayLayers;
                 }
             }
             else if (tex.Depth == 1)
@@ -44,16 +44,16 @@ namespace Veldrid.D3D11
                 {
                     if (tex.Type == TextureType.Texture1D)
                     {
-                        srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Texture1D;
+                        srvDesc.ViewDimension = Vortice.Direct3D.ShaderResourceViewDimension.Texture1D;
                         srvDesc.Texture1D.MostDetailedMip = (int)baseMipLevel;
                         srvDesc.Texture1D.MipLevels = (int)levelCount;
                     }
                     else
                     {
                         if (tex.SampleCount == TextureSampleCount.Count1)
-                            srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Texture2D;
+                            srvDesc.ViewDimension = Vortice.Direct3D.ShaderResourceViewDimension.Texture2D;
                         else
-                            srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Texture2DMultisampled;
+                            srvDesc.ViewDimension = Vortice.Direct3D.ShaderResourceViewDimension.Texture2DMultisampled;
                         srvDesc.Texture2D.MostDetailedMip = (int)baseMipLevel;
                         srvDesc.Texture2D.MipLevels = (int)levelCount;
                     }
@@ -62,7 +62,7 @@ namespace Veldrid.D3D11
                 {
                     if (tex.Type == TextureType.Texture1D)
                     {
-                        srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Texture1DArray;
+                        srvDesc.ViewDimension = Vortice.Direct3D.ShaderResourceViewDimension.Texture1DArray;
                         srvDesc.Texture1DArray.MostDetailedMip = (int)baseMipLevel;
                         srvDesc.Texture1DArray.MipLevels = (int)levelCount;
                         srvDesc.Texture1DArray.FirstArraySlice = (int)baseArrayLayer;
@@ -70,7 +70,7 @@ namespace Veldrid.D3D11
                     }
                     else
                     {
-                        srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Texture2DArray;
+                        srvDesc.ViewDimension = Vortice.Direct3D.ShaderResourceViewDimension.Texture2DArray;
                         srvDesc.Texture2DArray.MostDetailedMip = (int)baseMipLevel;
                         srvDesc.Texture2DArray.MipLevels = (int)levelCount;
                         srvDesc.Texture2DArray.FirstArraySlice = (int)baseArrayLayer;
@@ -80,7 +80,7 @@ namespace Veldrid.D3D11
             }
             else
             {
-                srvDesc.Dimension = SharpDX.Direct3D.ShaderResourceViewDimension.Texture3D;
+                srvDesc.ViewDimension = Vortice.Direct3D.ShaderResourceViewDimension.Texture3D;
                 srvDesc.Texture3D.MostDetailedMip = (int)baseMipLevel;
                 srvDesc.Texture3D.MipLevels = (int)levelCount;
             }

--- a/src/Veldrid/D3D11DeviceOptions.cs
+++ b/src/Veldrid/D3D11DeviceOptions.cs
@@ -14,7 +14,7 @@ namespace Veldrid
 
         /// <summary>
         /// Set of device specific flags.
-        /// See <see cref="SharpDX.Direct3D11.DeviceCreationFlags"/> for details.
+        /// See <see cref="Vortice.Direct3D11.DeviceCreationFlags"/> for details.
         /// </summary>
         public uint DeviceCreationFlags;
     }

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -938,8 +938,8 @@ namespace Veldrid
         /// Creates a new <see cref="GraphicsDevice"/> using Direct3D 11, with a main Swapchain.
         /// </summary>
         /// <param name="options">Describes several common properties of the GraphicsDevice.</param>
-        /// <param name="swapChainPanel">A COM object which must implement the <see cref="SharpDX.DXGI.ISwapChainPanelNative"/>
-        /// or <see cref="SharpDX.DXGI.ISwapChainBackgroundPanelNative"/> interface. Generally, this should be a SwapChainPanel
+        /// <param name="swapChainPanel">A COM object which must implement the <see cref="Vortice.DXGI.ISwapChainPanelNative"/>
+        /// or <see cref="Vortice.DXGI.ISwapChainBackgroundPanelNative"/> interface. Generally, this should be a SwapChainPanel
         /// or SwapChainBackgroundPanel contained in your application window.</param>
         /// <param name="renderWidth">The renderable width of the swapchain panel.</param>
         /// <param name="renderHeight">The renderable height of the swapchain panel.</param>

--- a/src/Veldrid/SwapchainSource.cs
+++ b/src/Veldrid/SwapchainSource.cs
@@ -24,8 +24,8 @@ namespace Veldrid
         /// <summary>
         /// Creates a new SwapchainSource for a UWP SwapChain panel.
         /// </summary>
-        /// <param name="swapChainPanel">A COM object which must implement the <see cref="SharpDX.DXGI.ISwapChainPanelNative"/>
-        /// or <see cref="SharpDX.DXGI.ISwapChainBackgroundPanelNative"/> interface. Generally, this should be a SwapChainPanel
+        /// <param name="swapChainPanel">A COM object which must implement the <see cref="Vortice.DXGI.ISwapChainPanelNative"/>
+        /// or <see cref="Vortice.DXGI.ISwapChainBackgroundPanelNative"/> interface. Generally, this should be a SwapChainPanel
         /// or SwapChainBackgroundPanel contained in your application window.</param>
         /// <param name="logicalDpi">The logical DPI of the swapchain panel.</param>
         /// <returns>A new SwapchainSource which can be used to create a <see cref="Swapchain"/> for the given UWP panel.

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -21,10 +21,10 @@
 
     <PackageReference Include="Vk" Version="1.0.22" Condition="'$(ExcludeVulkan)' != 'true'" />
 
-    <PackageReference Include="Vortice.D3DCompiler" Version="1.7.17-beta" />
-    <PackageReference Include="Vortice.Direct3D11" Version="1.7.17-beta" />
-    <PackageReference Include="Vortice.Dxc" Version="1.7.17-beta" />
-    <PackageReference Include="Vortice.DXGI" Version="1.7.17-beta" />
+    <PackageReference Include="Vortice.D3DCompiler" Version="1.7.33-beta" />
+    <PackageReference Include="Vortice.Direct3D11" Version="1.7.33-beta" />
+    <PackageReference Include="Vortice.Dxc" Version="1.7.33-beta" />
+    <PackageReference Include="Vortice.DXGI" Version="1.7.33-beta" />
 
     <ProjectReference Include="..\Veldrid.MetalBindings\Veldrid.MetalBindings.csproj" Condition="'$(ExcludeMetal)' != 'true'" />
 

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -21,13 +21,10 @@
 
     <PackageReference Include="Vk" Version="1.0.22" Condition="'$(ExcludeVulkan)' != 'true'" />
 
-    <PackageReference Include="Vortice.D3DCompiler" Version="1.7.14-beta" />
-
-    <PackageReference Include="Vortice.Direct3D11" Version="1.7.14-beta" />
-
-    <PackageReference Include="Vortice.Dxc" Version="1.7.14-beta" />
-
-    <PackageReference Include="Vortice.DXGI" Version="1.7.14-beta" />
+    <PackageReference Include="Vortice.D3DCompiler" Version="1.7.17-beta" />
+    <PackageReference Include="Vortice.Direct3D11" Version="1.7.17-beta" />
+    <PackageReference Include="Vortice.Dxc" Version="1.7.17-beta" />
+    <PackageReference Include="Vortice.DXGI" Version="1.7.17-beta" />
 
     <ProjectReference Include="..\Veldrid.MetalBindings\Veldrid.MetalBindings.csproj" Condition="'$(ExcludeMetal)' != 'true'" />
 

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -15,16 +15,19 @@
 
   <ItemGroup>
     <PackageReference Include="System.Buffers" Version="4.4.0" />
-    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
-    <PackageReference Include="NativeLibraryLoader" Version="$(NativeLibraryLoaderVersion)" />
-
-    <PackageReference Include="SharpDX" Version="4.0.1" Condition="'$(ExcludeD3D11)' != 'true'" />
-    <PackageReference Include="SharpDX.D3DCompiler" Version="4.0.1" Condition="'$(ExcludeD3D11)' != 'true'" />
-    <PackageReference Include="SharpDX.Direct3D11" Version="4.0.1" Condition="'$(ExcludeD3D11)' != 'true'" />
-    <PackageReference Include="SharpDX.DXGI" Version="4.0.1" Condition="'$(ExcludeD3D11)' != 'true'" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
+    <PackageReference Include="NativeLibraryLoader" Version="1.0.12" />
 
     <PackageReference Include="Vk" Version="1.0.22" Condition="'$(ExcludeVulkan)' != 'true'" />
+
+    <PackageReference Include="Vortice.D3DCompiler" Version="1.6.0" />
+
+    <PackageReference Include="Vortice.Direct3D11" Version="1.6.0" />
+
+    <PackageReference Include="Vortice.Dxc" Version="1.6.0" />
+
+    <PackageReference Include="Vortice.DXGI" Version="1.6.0" />
 
     <ProjectReference Include="..\Veldrid.MetalBindings\Veldrid.MetalBindings.csproj" Condition="'$(ExcludeMetal)' != 'true'" />
 

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -16,18 +16,18 @@
   <ItemGroup>
     <PackageReference Include="System.Buffers" Version="4.4.0" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="NativeLibraryLoader" Version="1.0.12" />
 
     <PackageReference Include="Vk" Version="1.0.22" Condition="'$(ExcludeVulkan)' != 'true'" />
 
-    <PackageReference Include="Vortice.D3DCompiler" Version="1.6.0" />
+    <PackageReference Include="Vortice.D3DCompiler" Version="1.7.14-beta" />
 
-    <PackageReference Include="Vortice.Direct3D11" Version="1.6.0" />
+    <PackageReference Include="Vortice.Direct3D11" Version="1.7.14-beta" />
 
-    <PackageReference Include="Vortice.Dxc" Version="1.6.0" />
+    <PackageReference Include="Vortice.Dxc" Version="1.7.14-beta" />
 
-    <PackageReference Include="Vortice.DXGI" Version="1.6.0" />
+    <PackageReference Include="Vortice.DXGI" Version="1.7.14-beta" />
 
     <ProjectReference Include="..\Veldrid.MetalBindings\Veldrid.MetalBindings.csproj" Condition="'$(ExcludeMetal)' != 'true'" />
 


### PR DESCRIPTION
Since SharpDX has been archive and is not developed anymore (see https://github.com/sharpdx/SharpDX), it has to be replaced if new features like mesh shaders or raytracing shaders. I'm planning to do a D3D12 based on this afterwards.

@amerkoleci created a library called [Vortice.Windows](https://github.com/amerkoleci/Vortice.Windows/), which has similar goals and is actively developed. 
It is much closer to the original C++ Api, due to it's SharpGen usage.

I'm opening this as a draft since there are still some things that need to be figured out before.