### PR TITLE
DCI-P3 support for Retina Display

### DIFF
--- a/src/Veldrid/MTL/MTLSwapchain.cs
+++ b/src/Veldrid/MTL/MTLSwapchain.cs
@@ -83,7 +83,7 @@ namespace Veldrid.MTL
             }
 
             PixelFormat format = description.ColorSrgb
-                ? PixelFormat.R16_G16_B16_A16_Float;
+                ? PixelFormat.R16_G16_B16_A16_Float; // Deep Color (DCI-P3 support for Retina Display)
                 : PixelFormat.B8_G8_R8_A8_UNorm;
 
             _metalLayer.device = _gd.Device;

--- a/src/Veldrid/MTL/MTLSwapchain.cs
+++ b/src/Veldrid/MTL/MTLSwapchain.cs
@@ -83,7 +83,7 @@ namespace Veldrid.MTL
             }
 
             PixelFormat format = description.ColorSrgb
-                ? PixelFormat.B8_G8_R8_A8_UNorm_SRgb
+                ? PixelFormat.R16_G16_B16_A16_Float;
                 : PixelFormat.B8_G8_R8_A8_UNorm;
 
             _metalLayer.device = _gd.Device;


### PR DESCRIPTION
On MacOS, DCI-P3 color space and 1 billion color display are enabled in Retinal Display by specifying R16_G16_B16_A16_Float.
