### PR TITLE
D3D11 fix and leakage improvements

### DIFF
--- a/src/Veldrid/D3D11/D3D11CommandList.cs
+++ b/src/Veldrid/D3D11/D3D11CommandList.cs
@@ -1054,11 +1054,11 @@ namespace Veldrid.D3D11
                     int slot = list[i].Item2;
                     if (compute)
                     {
-                        _context.CSResetUnorderedAccessView(slot);
+                        _context.CSUnsetUnorderedAccessView(slot);
                     }
                     else
                     {
-                        _context.OMResetUnorderedAccessView(slot);
+                        _context.OMUnsetUnorderedAccessView(slot);
                     }
 
                     list.RemoveAt(i);
@@ -1377,6 +1377,12 @@ namespace Veldrid.D3D11
                 {
                     boundComputeSet.Offsets.Dispose();
                 }
+
+                foreach (D3D11Buffer buffer in _availableStagingBuffers)
+                {
+                    buffer.Dispose();
+                }
+                _availableStagingBuffers.Clear();
 
                 _disposed = true;
             }

--- a/src/Veldrid/D3D11/D3D11CommandList.cs
+++ b/src/Veldrid/D3D11/D3D11CommandList.cs
@@ -383,24 +383,24 @@ namespace Veldrid.D3D11
                 switch (rbi.Kind)
                 {
                     case ResourceKind.UniformBuffer:
-                    {
-                        D3D11BufferRange range = GetBufferRange(resource, bufferOffset);
-                        BindUniformBuffer(range, cbBase + rbi.Slot, rbi.Stages);
-                        break;
-                    }
+                        {
+                            D3D11BufferRange range = GetBufferRange(resource, bufferOffset);
+                            BindUniformBuffer(range, cbBase + rbi.Slot, rbi.Stages);
+                            break;
+                        }
                     case ResourceKind.StructuredBufferReadOnly:
-                    {
-                        D3D11BufferRange range = GetBufferRange(resource, bufferOffset);
-                        BindStorageBufferView(range, textureBase + rbi.Slot, rbi.Stages);
-                        break;
-                    }
+                        {
+                            D3D11BufferRange range = GetBufferRange(resource, bufferOffset);
+                            BindStorageBufferView(range, textureBase + rbi.Slot, rbi.Stages);
+                            break;
+                        }
                     case ResourceKind.StructuredBufferReadWrite:
-                    {
-                        D3D11BufferRange range = GetBufferRange(resource, bufferOffset);
-                        ID3D11UnorderedAccessView uav = range.Buffer.GetUnorderedAccessView(range.Offset, range.Size);
-                        BindUnorderedAccessView(null, range.Buffer, uav, uaBase + rbi.Slot, rbi.Stages, slot);
-                        break;
-                    }
+                        {
+                            D3D11BufferRange range = GetBufferRange(resource, bufferOffset);
+                            ID3D11UnorderedAccessView uav = range.Buffer.GetUnorderedAccessView(range.Offset, range.Size);
+                            BindUnorderedAccessView(null, range.Buffer, uav, uaBase + rbi.Slot, rbi.Stages, slot);
+                            break;
+                        }
                     case ResourceKind.TextureReadOnly:
                         TextureView texView = Util.GetTextureView(_gd, resource);
                         D3D11TextureView d3d11TexView = Util.AssertSubtype<TextureView, D3D11TextureView>(texView);
@@ -705,7 +705,7 @@ namespace Veldrid.D3D11
                     _vertexBindings,
                     _vertexStrides,
                     _vertexOffsets);
-            
+
                 _vertexBindingsChanged = false;
             }
         }
@@ -887,14 +887,14 @@ namespace Veldrid.D3D11
             {
                 if (range.IsFullRange)
                 {
-                    _context.GSSetConstantBuffers(slot, range.Buffer.Buffer);
+                    _context.GSSetConstantBuffer(slot, range.Buffer.Buffer);
                 }
                 else
                 {
                     PackRangeParams(range);
                     if (!_gd.SupportsCommandLists)
                     {
-                        _context.GSSetConstantBuffers(slot, (ID3D11Buffer)null);
+                        _context.GSSetConstantBuffer(slot, (ID3D11Buffer)null);
                     }
                     _context1.GSSetConstantBuffers1(slot, 1, _cbOut, _firstConstRef, _numConstsRef);
                 }
@@ -903,14 +903,14 @@ namespace Veldrid.D3D11
             {
                 if (range.IsFullRange)
                 {
-                    _context.HSSetConstantBuffers(slot, range.Buffer.Buffer);
+                    _context.HSSetConstantBuffer(slot, range.Buffer.Buffer);
                 }
                 else
                 {
                     PackRangeParams(range);
                     if (!_gd.SupportsCommandLists)
                     {
-                        _context.HSSetConstantBuffers(slot, (ID3D11Buffer)null);
+                        _context.HSSetConstantBuffer(slot, (ID3D11Buffer)null);
                     }
                     _context1.HSSetConstantBuffers1(slot, 1, _cbOut, _firstConstRef, _numConstsRef);
                 }
@@ -919,14 +919,14 @@ namespace Veldrid.D3D11
             {
                 if (range.IsFullRange)
                 {
-                    _context.DSSetConstantBuffers(slot, range.Buffer.Buffer);
+                    _context.DSSetConstantBuffer(slot, range.Buffer.Buffer);
                 }
                 else
                 {
                     PackRangeParams(range);
                     if (!_gd.SupportsCommandLists)
                     {
-                        _context.DSSetConstantBuffers(slot, (ID3D11Buffer)null);
+                        _context.DSSetConstantBuffer(slot, (ID3D11Buffer)null);
                     }
                     _context1.DSSetConstantBuffers1(slot, 1, _cbOut, _firstConstRef, _numConstsRef);
                 }
@@ -957,7 +957,7 @@ namespace Veldrid.D3D11
                         PackRangeParams(range);
                         if (!_gd.SupportsCommandLists)
                         {
-                            _context.PSSetConstantBuffers(slot, (ID3D11Buffer)null);
+                            _context.PSSetConstantBuffer(slot, (ID3D11Buffer)null);
                         }
                         _context1.PSSetConstantBuffers1(slot, 1, _cbOut, _firstConstRef, _numConstsRef);
                     }
@@ -967,14 +967,14 @@ namespace Veldrid.D3D11
             {
                 if (range.IsFullRange)
                 {
-                    _context.CSSetConstantBuffers(slot, range.Buffer.Buffer);
+                    _context.CSSetConstantBuffer(slot, range.Buffer.Buffer);
                 }
                 else
                 {
                     PackRangeParams(range);
                     if (!_gd.SupportsCommandLists)
                     {
-                        _context.CSSetConstantBuffers(slot, (ID3D11Buffer)null);
+                        _context.CSSetConstantBuffer(slot, (ID3D11Buffer)null);
                     }
                     _context1.CSSetConstantBuffers1(slot, 1, _cbOut, _firstConstRef, _numConstsRef);
                 }
@@ -1029,7 +1029,7 @@ namespace Veldrid.D3D11
             }
             else
             {
-                _context.SetUnorderedAccessViews(actualSlot, new[] { uav }, null);
+                _context.OMSetUnorderedAccessView(actualSlot, uav);
             }
         }
 
@@ -1059,7 +1059,7 @@ namespace Veldrid.D3D11
                     }
                     else
                     {
-                        _context.SetUnorderedAccessViews(slot, new ID3D11UnorderedAccessView[] { null }, new[] { -1 });
+                        _context.OMSetUnorderedAccessView(slot, null);
                     }
 
                     list.RemoveAt(i);
@@ -1191,11 +1191,11 @@ namespace Veldrid.D3D11
             }
             else if (useMap && updateFullBuffer) // Can only update full buffer with WriteDiscard.
             {
-               MappedSubresource msb = _context.Map(
-                    d3dBuffer.Buffer,
-                    0,
-                    D3D11Formats.VdToD3D11MapMode(isDynamic, MapMode.Write),
-                    MapFlags.None);
+                MappedSubresource msb = _context.Map(
+                     d3dBuffer.Buffer,
+                     0,
+                     D3D11Formats.VdToD3D11MapMode(isDynamic, MapMode.Write),
+                     MapFlags.None);
                 if (sizeInBytes < 1024)
                 {
                     Unsafe.CopyBlock(msb.DataPointer.ToPointer(), source.ToPointer(), sizeInBytes);

--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -594,6 +594,13 @@ namespace Veldrid.D3D11
 
         protected override void PlatformDispose()
         {
+            // Dispose staging buffers
+            foreach (DeviceBuffer buffer in _availableStagingBuffers)
+            {
+                buffer.Dispose();
+            }
+            _availableStagingBuffers.Clear();
+
             _d3d11ResourceFactory.Dispose();
             _mainSwapchain?.Dispose();
             _immediateContext.Dispose();
@@ -603,6 +610,7 @@ namespace Veldrid.D3D11
             _device.Dispose();
             _dxgiAdapter?.Dispose();
 
+            // Need to enable native debugging to see live objects in VisualStudio console.
             if (deviceDebug != null)
             {
                 deviceDebug.ReportLiveDeviceObjects(ReportLiveDeviceObjectFlags.Summary | ReportLiveDeviceObjectFlags.Detail | ReportLiveDeviceObjectFlags.IgnoreInternal);

--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Vortice.Mathematics;
+using Vortice.Direct3D11.Debug;
 
 namespace Veldrid.D3D11
 {
@@ -52,7 +53,7 @@ namespace Veldrid.D3D11
         public override GraphicsDeviceFeatures Features { get; }
 
         public D3D11GraphicsDevice(GraphicsDeviceOptions options, D3D11DeviceOptions d3D11DeviceOptions, SwapchainDescription? swapchainDesc)
-            :this(MergeOptions(d3D11DeviceOptions, options), swapchainDesc)
+            : this(MergeOptions(d3D11DeviceOptions, options), swapchainDesc)
         {
         }
 
@@ -76,10 +77,10 @@ namespace Veldrid.D3D11
                     Vortice.Direct3D11.D3D11.D3D11CreateDevice(_dxgiAdapter,
                         Vortice.Direct3D.DriverType.Hardware,
                         flags,
-                        new[] 
-                        { 
-                            Vortice.Direct3D.FeatureLevel.Level_11_1, 
-                            Vortice.Direct3D.FeatureLevel.Level_11_0, 
+                        new[]
+                        {
+                            Vortice.Direct3D.FeatureLevel.Level_11_1,
+                            Vortice.Direct3D.FeatureLevel.Level_11_0,
                         },
                         out _device).CheckError();
                 }
@@ -88,10 +89,10 @@ namespace Veldrid.D3D11
                     Vortice.Direct3D11.D3D11.D3D11CreateDevice(null,
                         Vortice.Direct3D.DriverType.Hardware,
                         flags,
-                        new[] 
-                        { 
-                            Vortice.Direct3D.FeatureLevel.Level_11_1, 
-                            Vortice.Direct3D.FeatureLevel.Level_11_0, 
+                        new[]
+                        {
+                            Vortice.Direct3D.FeatureLevel.Level_11_1,
+                            Vortice.Direct3D.FeatureLevel.Level_11_0,
                         },
                         out _device).CheckError();
                 }
@@ -597,15 +598,14 @@ namespace Veldrid.D3D11
             _mainSwapchain?.Dispose();
             _immediateContext.Dispose();
 
-            IDXGIDebug deviceDebug = _device.QueryInterfaceOrNull<IDXGIDebug>();
+            ID3D11Debug deviceDebug = _device.QueryInterfaceOrNull<ID3D11Debug>();
 
             _device.Dispose();
             _dxgiAdapter?.Dispose();
 
             if (deviceDebug != null)
             {
-                deviceDebug.ReportLiveObjects(DXGI.All, ReportLiveObjectFlags.Summary);
-                deviceDebug.ReportLiveObjects(DXGI.All, ReportLiveObjectFlags.Detail);
+                deviceDebug.ReportLiveDeviceObjects(ReportLiveDeviceObjectFlags.Summary | ReportLiveDeviceObjectFlags.Detail | ReportLiveDeviceObjectFlags.IgnoreInternal);
                 deviceDebug.Dispose();
             }
         }

--- a/src/Veldrid/D3D11/D3D11Swapchain.cs
+++ b/src/Veldrid/D3D11/D3D11Swapchain.cs
@@ -115,7 +115,7 @@ namespace Veldrid.D3D11
                     Width = (int)(description.Width * _pixelScale),
                     SampleDescription = new SampleDescription(1, 0),
                     SwapEffect = SwapEffect.FlipSequential,
-                    Usage = Vortice.DXGI.Usage.Backbuffer | Vortice.DXGI.Usage.RenderTargetOutput,
+                    Usage = Vortice.DXGI.Usage.RenderTargetOutput,
                 };
 
                 // Retrive the Vortice.DXGI device associated to the Direct3D device.
@@ -181,7 +181,7 @@ namespace Veldrid.D3D11
             uint actualHeight = (uint)(height * _pixelScale);
             if (resizeBuffers)
             {
-                _dxgiSwapChain.ResizeBuffers(2, (int)actualWidth, (int)actualHeight, _colorFormat, SwapChainFlags.None);
+                _dxgiSwapChain.ResizeBuffers(2, (int)actualWidth, (int)actualHeight, _colorFormat, SwapChainFlags.None).CheckError();
             }
 
             // Get the backbuffer from the swapchain

--- a/src/Veldrid/D3D11/D3D11Swapchain.cs
+++ b/src/Veldrid/D3D11/D3D11Swapchain.cs
@@ -201,9 +201,12 @@ namespace Veldrid.D3D11
                     backBufferTexture,
                     TextureType.Texture2D,
                     D3D11Formats.ToVdFormat(_colorFormat));
+
                 FramebufferDescription desc = new FramebufferDescription(_depthTexture, backBufferVdTexture);
-                _framebuffer = new D3D11Framebuffer(_device, ref desc);
-                _framebuffer.Swapchain = this;
+                _framebuffer = new D3D11Framebuffer(_device, ref desc)
+                {
+                    Swapchain = this
+                };
             }
         }
 

--- a/src/Veldrid/D3D11/D3D11Util.cs
+++ b/src/Veldrid/D3D11/D3D11Util.cs
@@ -88,27 +88,5 @@ namespace Veldrid.D3D11
 
             return srvDesc;
         }
-
-        internal static void SetUnorderedAccessViewsKeepRTV(this ID3D11DeviceContext context, int startSlot, int numBuffers, IntPtr unorderedAccessBuffer, IntPtr uavCount)
-        {
-            context.OMSetRenderTargetsAndUnorderedAccessViews(
-                ID3D11DeviceContext.KeepRenderTargetsAndDepthStencil,
-                IntPtr.Zero, null, startSlot, numBuffers,
-                unorderedAccessBuffer, uavCount);
-        }
-
-        internal static unsafe void SetUnorderedAccessViews(this ID3D11DeviceContext context, int startSlot, ID3D11UnorderedAccessView[] unorderedAccessViews, int[] uavInitialCounts)
-        {
-            IntPtr* unorderedAccessViewsOut_ = (IntPtr*)0;
-            if (unorderedAccessViews != null)
-            {
-                IntPtr* unorderedAccessViewsOut__ = stackalloc IntPtr[unorderedAccessViews.Length];
-                unorderedAccessViewsOut_ = unorderedAccessViewsOut__;
-                for (int i = 0; i < unorderedAccessViews.Length; i++)
-                    unorderedAccessViewsOut_[i] = (unorderedAccessViews[i] == null) ? IntPtr.Zero : unorderedAccessViews[i].NativePointer;
-            }
-            fixed (void* puav = uavInitialCounts)
-                context.SetUnorderedAccessViewsKeepRTV(startSlot, unorderedAccessViews != null ? unorderedAccessViews.Length : 0, (IntPtr)unorderedAccessViewsOut_, (IntPtr)puav);
-        }
     }
 }

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -21,10 +21,10 @@
 
     <PackageReference Include="Vk" Version="1.0.22" Condition="'$(ExcludeVulkan)' != 'true'" />
 
-    <PackageReference Include="Vortice.D3DCompiler" Version="1.8.3" />
-    <PackageReference Include="Vortice.Direct3D11" Version="1.8.3" />
-    <PackageReference Include="Vortice.Dxc" Version="1.8.3" />
-    <PackageReference Include="Vortice.DXGI" Version="1.8.3" />
+    <PackageReference Include="Vortice.D3DCompiler" Version="1.8.5" />
+    <PackageReference Include="Vortice.Direct3D11" Version="1.8.5" />
+    <PackageReference Include="Vortice.Dxc" Version="1.8.5" />
+    <PackageReference Include="Vortice.DXGI" Version="1.8.5" />
 
     <ProjectReference Include="..\Veldrid.MetalBindings\Veldrid.MetalBindings.csproj" Condition="'$(ExcludeMetal)' != 'true'" />
 

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -21,10 +21,10 @@
 
     <PackageReference Include="Vk" Version="1.0.22" Condition="'$(ExcludeVulkan)' != 'true'" />
 
-    <PackageReference Include="Vortice.D3DCompiler" Version="1.8.5" />
-    <PackageReference Include="Vortice.Direct3D11" Version="1.8.5" />
-    <PackageReference Include="Vortice.Dxc" Version="1.8.5" />
-    <PackageReference Include="Vortice.DXGI" Version="1.8.5" />
+    <PackageReference Include="Vortice.D3DCompiler" Version="1.8.6" />
+    <PackageReference Include="Vortice.Direct3D11" Version="1.8.6" />
+    <PackageReference Include="Vortice.Dxc" Version="1.8.6" />
+    <PackageReference Include="Vortice.DXGI" Version="1.8.6" />
 
     <ProjectReference Include="..\Veldrid.MetalBindings\Veldrid.MetalBindings.csproj" Condition="'$(ExcludeMetal)' != 'true'" />
 

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -21,10 +21,10 @@
 
     <PackageReference Include="Vk" Version="1.0.22" Condition="'$(ExcludeVulkan)' != 'true'" />
 
-    <PackageReference Include="Vortice.D3DCompiler" Version="1.7.37" />
-    <PackageReference Include="Vortice.Direct3D11" Version="1.7.37" />
-    <PackageReference Include="Vortice.Dxc" Version="1.7.37" />
-    <PackageReference Include="Vortice.DXGI" Version="1.7.37" />
+    <PackageReference Include="Vortice.D3DCompiler" Version="1.8.3" />
+    <PackageReference Include="Vortice.Direct3D11" Version="1.8.3" />
+    <PackageReference Include="Vortice.Dxc" Version="1.8.3" />
+    <PackageReference Include="Vortice.DXGI" Version="1.8.3" />
 
     <ProjectReference Include="..\Veldrid.MetalBindings\Veldrid.MetalBindings.csproj" Condition="'$(ExcludeMetal)' != 'true'" />
 


### PR DESCRIPTION
This fixes:
- ID3D11CommandList leakage with new method.
- ReportLiveObjects during D3D11 device dispose which was wrong.
- Staging buffers not being disposed.
- Calls non array ID3D11DeviceContext methods.