### PR TITLE
Cap length of OpenGL debug names

### DIFF
--- a/src/Veldrid.OpenGLBindings/Enums.cs
+++ b/src/Veldrid.OpenGLBindings/Enums.cs
@@ -1437,6 +1437,7 @@ namespace Veldrid.OpenGLBinding
         ViewportBoundsRange = 33373,
         LayerProvokingVertex = 33374,
         ViewportIndexProvokingVertex = 33375,
+        MaxLabelLength = 33512,
         MaxCullDistances = 33529,
         MaxCombinedClipAndCullDistances = 33530,
         ContextReleaseBehavior = 33531,

--- a/src/Veldrid/OpenGL/OpenGLUtil.cs
+++ b/src/Veldrid/OpenGL/OpenGLUtil.cs
@@ -7,6 +7,8 @@ namespace Veldrid.OpenGL
 {
     internal static class OpenGLUtil
     {
+        private static int? MaxLabelLength;
+
         [Conditional("DEBUG")]
         [DebuggerNonUserCode]
         internal static void CheckLastError()
@@ -28,6 +30,19 @@ namespace Veldrid.OpenGL
             if (HasGlObjectLabel)
             {
                 int byteCount = Encoding.UTF8.GetByteCount(name);
+                if (MaxLabelLength == null)
+                {
+                    int maxLabelLength = -1;
+                    glGetIntegerv(GetPName.MaxLabelLength, &maxLabelLength);
+                    CheckLastError();
+                    MaxLabelLength = maxLabelLength;
+                }
+                if (byteCount >= MaxLabelLength)
+                {
+                    name = name.Substring(0, MaxLabelLength.Value - 4) + "...";
+                    byteCount = Encoding.UTF8.GetByteCount(name);
+                }
+
                 byte* utf8Ptr = stackalloc byte[byteCount];
                 fixed (char* namePtr = name)
                 {


### PR DESCRIPTION
Ran into a small error where I set too long names for OpenGL - this limits the length of those names