### PR TITLE
Add SDL_GetWindowDisplayIndex and SDL_GetCurrentDisplayMode

### DIFF
--- a/src/Veldrid.SDL2/Sdl2.Window.cs
+++ b/src/Veldrid.SDL2/Sdl2.Window.cs
@@ -116,6 +116,16 @@ namespace Veldrid.Sdl2
         public static void SDL_SetWindowResizable(SDL_Window window, uint resizable) => s_setWindowResizable(window, resizable);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int SDL_GetWindowDisplayIndex_t(SDL_Window window);
+        private static SDL_GetWindowDisplayIndex_t s_sdl_getWindowDisplayIndex = LoadFunction<SDL_GetWindowDisplayIndex_t>("SDL_GetWindowDisplayIndex");
+        public static int SDL_GetWindowDisplayIndex(SDL_Window window) => s_sdl_getWindowDisplayIndex(window);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int SDL_GetCurrentDisplayMode_t(int displayIndex, SDL_DisplayMode* mode);
+        private static SDL_GetCurrentDisplayMode_t s_sdl_getCurrentDisplayMode = LoadFunction<SDL_GetCurrentDisplayMode_t>("SDL_GetCurrentDisplayMode");
+        public static int SDL_GetCurrentDisplayMode(int displayIndex, SDL_DisplayMode* mode) => s_sdl_getCurrentDisplayMode(displayIndex, mode);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int SDL_GetDesktopDisplayMode_t(int displayIndex, SDL_DisplayMode* mode);
         private static SDL_GetDesktopDisplayMode_t s_sdl_getDesktopDisplayMode = LoadFunction<SDL_GetDesktopDisplayMode_t>("SDL_GetDesktopDisplayMode");
         public static int SDL_GetDesktopDisplayMode(int displayIndex, SDL_DisplayMode* mode) => s_sdl_getDesktopDisplayMode(displayIndex, mode);

--- a/src/Veldrid.SDL2/Sdl2.Window.cs
+++ b/src/Veldrid.SDL2/Sdl2.Window.cs
@@ -116,6 +116,11 @@ namespace Veldrid.Sdl2
         public static void SDL_SetWindowResizable(SDL_Window window, uint resizable) => s_setWindowResizable(window, resizable);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int SDL_GetDisplayBounds_t(int displayIndex, SDL_Rect* rect);
+        private static SDL_GetDisplayBounds_t s_sdl_getDisplayBounds = LoadFunction<SDL_GetDisplayBounds_t>("SDL_GetDisplayBounds");
+        public static int SDL_GetDisplayBounds(int displayIndex, SDL_Rect* rect) => s_sdl_getDisplayBounds(displayIndex, rect);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int SDL_GetWindowDisplayIndex_t(SDL_Window window);
         private static SDL_GetWindowDisplayIndex_t s_sdl_getWindowDisplayIndex = LoadFunction<SDL_GetWindowDisplayIndex_t>("SDL_GetWindowDisplayIndex");
         public static int SDL_GetWindowDisplayIndex(SDL_Window window) => s_sdl_getWindowDisplayIndex(window);

--- a/src/Veldrid.SDL2/Sdl2.Window.cs
+++ b/src/Veldrid.SDL2/Sdl2.Window.cs
@@ -238,4 +238,12 @@ namespace Veldrid.Sdl2
         public int refresh_rate;
         public void* driverdata;
     }
+
+    public struct SDL_Rect
+    {
+        public int x;
+        public int y;
+        public int w;
+        public int h;
+    }
 }


### PR DESCRIPTION
Similar to #308, adds two extra functions that I plan to use to get the current display size.

`SDL_GetWindowDisplayIndex` is to get the display that that a window is currently on.

`SDL_GetCurrentDisplayMode` is to get the size of that display.

I don't want to use `SDL_GetDesktopDisplayMode` as according to the documentation the result of this method doesn't change when a window is fullscreen on the display with a different resolution, whereas I would want the changed resolution.

Also: unintentional, but it changes the line endings of the file to be uniformly LF. Can change back if wanted