### PR TITLE
Add Name property to GraphicsDevice

### DIFF
--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -17,6 +17,7 @@ namespace Veldrid.D3D11
     {
         private readonly IDXGIAdapter _dxgiAdapter;
         private readonly ID3D11Device _device;
+        private readonly string _name;
         private readonly ID3D11DeviceContext _immediateContext;
         private readonly D3D11ResourceFactory _d3d11ResourceFactory;
         private readonly D3D11Swapchain _mainSwapchain;
@@ -31,6 +32,8 @@ namespace Veldrid.D3D11
 
         private readonly object _stagingResourcesLock = new object();
         private readonly List<D3D11Buffer> _availableStagingBuffers = new List<D3D11Buffer>();
+
+        public override string Name => _name;
 
         public override GraphicsBackend BackendType => GraphicsBackend.Direct3D11;
 
@@ -112,6 +115,7 @@ namespace Veldrid.D3D11
                 // Store a pointer to the DXGI adapter.
                 // This is for the case of no preferred DXGI adapter, or fallback to WARP.
                 dxgiDevice.GetAdapter(out _dxgiAdapter).CheckError();
+                _name = _dxgiAdapter.Description.Description;
             }
 
             if (swapchainDesc != null)

--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -17,7 +17,7 @@ namespace Veldrid.D3D11
     {
         private readonly IDXGIAdapter _dxgiAdapter;
         private readonly ID3D11Device _device;
-        private readonly string _name;
+        private readonly string _deviceName;
         private readonly ID3D11DeviceContext _immediateContext;
         private readonly D3D11ResourceFactory _d3d11ResourceFactory;
         private readonly D3D11Swapchain _mainSwapchain;
@@ -33,7 +33,7 @@ namespace Veldrid.D3D11
         private readonly object _stagingResourcesLock = new object();
         private readonly List<D3D11Buffer> _availableStagingBuffers = new List<D3D11Buffer>();
 
-        public override string Name => _name;
+        public override string DeviceName => _deviceName;
 
         public override GraphicsBackend BackendType => GraphicsBackend.Direct3D11;
 
@@ -115,7 +115,7 @@ namespace Veldrid.D3D11
                 // Store a pointer to the DXGI adapter.
                 // This is for the case of no preferred DXGI adapter, or fallback to WARP.
                 dxgiDevice.GetAdapter(out _dxgiAdapter).CheckError();
-                _name = _dxgiAdapter.Description.Description;
+                _deviceName = _dxgiAdapter.Description.Description;
             }
 
             if (swapchainDesc != null)

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -20,7 +20,7 @@ namespace Veldrid
         /// <summary>
         /// Gets the name of the device.
         /// </summary>
-        public abstract string Name { get; }
+        public abstract string DeviceName { get; }
 
         /// <summary>
         /// Gets a value identifying the specific graphics API used by this instance.

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -18,6 +18,11 @@ namespace Veldrid
         internal GraphicsDevice() { }
 
         /// <summary>
+        /// Gets the name of the device.
+        /// </summary>
+        public abstract string Name { get; }
+
+        /// <summary>
         /// Gets a value identifying the specific graphics API used by this instance.
         /// </summary>
         public abstract GraphicsBackend BackendType { get; }

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -17,6 +17,7 @@ namespace Veldrid.MTL
             = new Dictionary<IntPtr, MTLGraphicsDevice>();
 
         private readonly MTLDevice _device;
+        private readonly string _name;
         private readonly MTLCommandQueue _commandQueue;
         private readonly MTLSwapchain _mainSwapchain;
         private readonly bool[] _supportedSampleCounts;
@@ -50,6 +51,7 @@ namespace Veldrid.MTL
             SwapchainDescription? swapchainDesc)
         {
             _device = MTLDevice.MTLCreateSystemDefaultDevice();
+            _name = _device.name;
             MetalFeatures = new MTLFeatureSupport(_device);
             Features = new GraphicsDeviceFeatures(
                 computeShader: true,
@@ -127,6 +129,8 @@ namespace Veldrid.MTL
 
             PostDeviceCreated();
         }
+
+        public override string Name => _name;
 
         public override GraphicsBackend BackendType => GraphicsBackend.Metal;
 

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -17,7 +17,7 @@ namespace Veldrid.MTL
             = new Dictionary<IntPtr, MTLGraphicsDevice>();
 
         private readonly MTLDevice _device;
-        private readonly string _name;
+        private readonly string _deviceName;
         private readonly MTLCommandQueue _commandQueue;
         private readonly MTLSwapchain _mainSwapchain;
         private readonly bool[] _supportedSampleCounts;
@@ -51,7 +51,7 @@ namespace Veldrid.MTL
             SwapchainDescription? swapchainDesc)
         {
             _device = MTLDevice.MTLCreateSystemDefaultDevice();
-            _name = _device.name;
+            _deviceName = _device.name;
             MetalFeatures = new MTLFeatureSupport(_device);
             Features = new GraphicsDeviceFeatures(
                 computeShader: true,
@@ -130,7 +130,7 @@ namespace Veldrid.MTL
             PostDeviceCreated();
         }
 
-        public override string Name => _name;
+        public override string DeviceName => _deviceName;
 
         public override GraphicsBackend BackendType => GraphicsBackend.Metal;
 

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -17,6 +17,7 @@ namespace Veldrid.OpenGL
     internal unsafe class OpenGLGraphicsDevice : GraphicsDevice
     {
         private ResourceFactory _resourceFactory;
+        private string _name;
         private GraphicsBackend _backendType;
         private GraphicsDeviceFeatures _features;
         private uint _vao;
@@ -63,6 +64,8 @@ namespace Veldrid.OpenGL
 
         public int MajorVersion { get; private set; }
         public int MinorVersion { get; private set; }
+
+        public override string Name => _name;
 
         public override GraphicsBackend BackendType => _backendType;
 
@@ -122,6 +125,7 @@ namespace Veldrid.OpenGL
             _setSyncToVBlank = platformInfo.SetSyncToVerticalBlank;
             LoadGetString(_glContext, platformInfo.GetProcAddress);
             string version = Util.GetString(glGetString(StringName.Version));
+            _name = Util.GetString(glGetString(StringName.Renderer));
             _backendType = version.StartsWith("OpenGL ES") ? GraphicsBackend.OpenGLES : GraphicsBackend.OpenGL;
 
             LoadAllFunctions(_glContext, platformInfo.GetProcAddress, _backendType == GraphicsBackend.OpenGLES);

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -17,7 +17,7 @@ namespace Veldrid.OpenGL
     internal unsafe class OpenGLGraphicsDevice : GraphicsDevice
     {
         private ResourceFactory _resourceFactory;
-        private string _name;
+        private string _deviceName;
         private GraphicsBackend _backendType;
         private GraphicsDeviceFeatures _features;
         private uint _vao;
@@ -65,7 +65,7 @@ namespace Veldrid.OpenGL
         public int MajorVersion { get; private set; }
         public int MinorVersion { get; private set; }
 
-        public override string Name => _name;
+        public override string DeviceName => _deviceName;
 
         public override GraphicsBackend BackendType => _backendType;
 
@@ -125,7 +125,7 @@ namespace Veldrid.OpenGL
             _setSyncToVBlank = platformInfo.SetSyncToVerticalBlank;
             LoadGetString(_glContext, platformInfo.GetProcAddress);
             string version = Util.GetString(glGetString(StringName.Version));
-            _name = Util.GetString(glGetString(StringName.Renderer));
+            _deviceName = Util.GetString(glGetString(StringName.Renderer));
             _backendType = version.StartsWith("OpenGL ES") ? GraphicsBackend.OpenGLES : GraphicsBackend.OpenGL;
 
             LoadAllFunctions(_glContext, platformInfo.GetProcAddress, _backendType == GraphicsBackend.OpenGLES);

--- a/src/Veldrid/Vk/VkGraphicsDevice.cs
+++ b/src/Veldrid/Vk/VkGraphicsDevice.cs
@@ -18,6 +18,7 @@ namespace Veldrid.Vk
 
         private VkInstance _instance;
         private VkPhysicalDevice _physicalDevice;
+        private string _name;
         private VkDeviceMemoryManager _memoryManager;
         private VkPhysicalDeviceProperties _physicalDeviceProperties;
         private VkPhysicalDeviceFeatures _physicalDeviceFeatures;
@@ -62,6 +63,8 @@ namespace Veldrid.Vk
             = new Dictionary<VkCommandBuffer, VkBuffer>();
         private readonly Dictionary<VkCommandBuffer, SharedCommandPool> _submittedSharedCommandPools
             = new Dictionary<VkCommandBuffer, SharedCommandPool>();
+
+        public override string Name => _name;
 
         public override GraphicsBackend BackendType => GraphicsBackend.Vulkan;
 
@@ -635,10 +638,9 @@ namespace Veldrid.Vk
             _physicalDevice = physicalDevices[0];
 
             vkGetPhysicalDeviceProperties(_physicalDevice, out _physicalDeviceProperties);
-            string deviceName;
             fixed (byte* utf8NamePtr = _physicalDeviceProperties.deviceName)
             {
-                deviceName = Encoding.UTF8.GetString(utf8NamePtr, (int)MaxPhysicalDeviceNameSize);
+                _name = Encoding.UTF8.GetString(utf8NamePtr, (int)MaxPhysicalDeviceNameSize).TrimEnd('\0');
             }
 
             vkGetPhysicalDeviceFeatures(_physicalDevice, out _physicalDeviceFeatures);

--- a/src/Veldrid/Vk/VkGraphicsDevice.cs
+++ b/src/Veldrid/Vk/VkGraphicsDevice.cs
@@ -18,7 +18,7 @@ namespace Veldrid.Vk
 
         private VkInstance _instance;
         private VkPhysicalDevice _physicalDevice;
-        private string _name;
+        private string _deviceName;
         private VkDeviceMemoryManager _memoryManager;
         private VkPhysicalDeviceProperties _physicalDeviceProperties;
         private VkPhysicalDeviceFeatures _physicalDeviceFeatures;
@@ -64,7 +64,7 @@ namespace Veldrid.Vk
         private readonly Dictionary<VkCommandBuffer, SharedCommandPool> _submittedSharedCommandPools
             = new Dictionary<VkCommandBuffer, SharedCommandPool>();
 
-        public override string Name => _name;
+        public override string DeviceName => _deviceName;
 
         public override GraphicsBackend BackendType => GraphicsBackend.Vulkan;
 
@@ -640,7 +640,7 @@ namespace Veldrid.Vk
             vkGetPhysicalDeviceProperties(_physicalDevice, out _physicalDeviceProperties);
             fixed (byte* utf8NamePtr = _physicalDeviceProperties.deviceName)
             {
-                _name = Encoding.UTF8.GetString(utf8NamePtr, (int)MaxPhysicalDeviceNameSize).TrimEnd('\0');
+                _deviceName = Encoding.UTF8.GetString(utf8NamePtr, (int)MaxPhysicalDeviceNameSize).TrimEnd('\0');
             }
 
             vkGetPhysicalDeviceFeatures(_physicalDevice, out _physicalDeviceFeatures);


### PR DESCRIPTION
This allows users of the library to access the debug name of the graphics device, so that it can be displayed to the user for debugging.

Tested every backend except for Metal, as I don't have a Mac. I see no reason why it shouldn't work though.