### PR TITLE
Fixed redundant OpenGL vertex layout calls (#312)

### DIFF
--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -35,6 +35,7 @@ namespace Veldrid.OpenGL
         private bool[] _newComputeResourceSets = Array.Empty<bool>();
 
         private bool _graphicsPipelineActive;
+        private bool _vertexLayoutFlushed;
 
         public OpenGLCommandExecutor(OpenGLGraphicsDevice gd, OpenGLPlatformInfo platformInfo)
         {
@@ -252,7 +253,11 @@ namespace Veldrid.OpenGL
             }
 
             FlushResourceSets(graphics: true);
-            FlushVertexLayouts();
+            if (!_vertexLayoutFlushed)
+            {
+                FlushVertexLayouts();
+                _vertexLayoutFlushed = true;
+            }
         }
 
         private void FlushResourceSets(bool graphics)
@@ -457,11 +462,13 @@ namespace Veldrid.OpenGL
             {
                 _graphicsPipeline = Util.AssertSubtype<Pipeline, OpenGLPipeline>(pipeline);
                 ActivateGraphicsPipeline();
+                _vertexLayoutFlushed = false;
             }
             else if (pipeline.IsComputePipeline && _computePipeline != pipeline)
             {
                 _computePipeline = Util.AssertSubtype<Pipeline, OpenGLPipeline>(pipeline);
                 ActivateComputePipeline();
+                _vertexLayoutFlushed = false;
             }
         }
 
@@ -1068,6 +1075,7 @@ namespace Veldrid.OpenGL
 
             Util.EnsureArrayMinimumSize(ref _vertexBuffers, index + 1);
             Util.EnsureArrayMinimumSize(ref _vbOffsets, index + 1);
+            _vertexLayoutFlushed = false;
             _vertexBuffers[index] = glVB;
             _vbOffsets[index] = offset;
         }


### PR DESCRIPTION
Fixes #312.

I don't have access to a development Windows machine at this moment (no bandwidth to set it up now) so I can't run the tests, but the NeoDemo seems to be working fine (Linux, OpenGL backend).

P.S.: Is there any plans for adding .gitattributes file to the repository? I've tried to commit the patch from a Linux machine, but it produced a full rewrite because the source file was misinterpreted as binary one because of the BOM mark at the start of the file.

Had to use the Github web interface to make this patch :neutral_face: 