### PR TITLE
Fixed window becoming stale in NeoDemo Camera

### DIFF
--- a/src/NeoDemo/Camera.cs
+++ b/src/NeoDemo/Camera.cs
@@ -46,10 +46,13 @@ namespace Veldrid.NeoDemo
             UpdateViewMatrix();
         }
 
-        public void UpdateBackend(GraphicsDevice gd)
+        public void UpdateBackend(GraphicsDevice gd, Sdl2Window window)
         {
             _gd = gd;
             _useReverseDepth = gd.IsDepthRangeZeroToOne;
+            _window = window;
+            _windowWidth = window.Width;
+            _windowHeight = window.Height;
             UpdatePerspectiveMatrix();
         }
 

--- a/src/NeoDemo/NeoDemo.cs
+++ b/src/NeoDemo/NeoDemo.cs
@@ -621,7 +621,7 @@ namespace Veldrid.NeoDemo
 #endif
             _gd = VeldridStartup.CreateGraphicsDevice(_window, gdOptions, backend);
 
-            _scene.Camera.UpdateBackend(_gd);
+            _scene.Camera.UpdateBackend(_gd, _window);
 
             CreateAllObjects();
         }


### PR DESCRIPTION
Somehow this doesn't throw on Windows.
On Linux you get a segfault if you try to use the stale Sdl2Window.