### PR TITLE
Resolved Isssue with using wrong variable for glBindFrameBuffer

### DIFF
--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -332,7 +332,7 @@ namespace Veldrid.OpenGL
             glGenFramebuffers(1, out uint copySrcFb);
             CheckLastError();
 
-            glBindFramebuffer(FramebufferTarget.ReadFramebuffer, copySrc);
+            glBindFramebuffer(FramebufferTarget.ReadFramebuffer, copySrcFb);
             CheckLastError();
             glFramebufferTexture2D(FramebufferTarget.ReadFramebuffer, GLFramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, copySrc, 0);
             CheckLastError();


### PR DESCRIPTION
Use the created framebuffer object instead of a texture object when binding an OpenGL framebuffer.