### PR TITLE
Improved SDL2 Native Pointer Extraction

### DIFF
--- a/src/Veldrid.SDL2/Sdl2.SysWMInfo.cs
+++ b/src/Veldrid.SDL2/Sdl2.SysWMInfo.cs
@@ -29,7 +29,7 @@ namespace Veldrid.Sdl2
         /// <summary>
         /// The Sdl2Window handle.
         /// </summary>
-        public IntPtr window;
+        public IntPtr Sdl2Window;
         /// <summary>
         /// The Sdl2Window device context.
         /// </summary>
@@ -43,7 +43,7 @@ namespace Veldrid.Sdl2
     public struct X11WindowInfo
     {
         public IntPtr display;
-        public IntPtr window;
+        public IntPtr Sdl2Window;
     }
 
     public struct WaylandWindowInfo

--- a/src/Veldrid.SDL2/Sdl2.SysWMInfo.cs
+++ b/src/Veldrid.SDL2/Sdl2.SysWMInfo.cs
@@ -29,7 +29,7 @@ namespace Veldrid.Sdl2
         /// <summary>
         /// The Sdl2Window handle.
         /// </summary>
-        public IntPtr Sdl2Window;
+        public IntPtr window;
         /// <summary>
         /// The Sdl2Window device context.
         /// </summary>
@@ -43,7 +43,7 @@ namespace Veldrid.Sdl2
     public struct X11WindowInfo
     {
         public IntPtr display;
-        public IntPtr Sdl2Window;
+        public IntPtr window;
     }
 
     public struct WaylandWindowInfo
@@ -58,7 +58,13 @@ namespace Veldrid.Sdl2
         /// <summary>
         /// The NSWindow* Cocoa window.
         /// </summary>
-        public IntPtr Window;
+        public IntPtr window;
+    }
+
+    public struct AndroidWindowInfo
+    {
+        public IntPtr window;
+        public IntPtr surface;
     }
 
     public enum SysWMType

--- a/src/Veldrid.SDL2/Sdl2Window.cs
+++ b/src/Veldrid.SDL2/Sdl2Window.cs
@@ -954,13 +954,26 @@ namespace Veldrid.Sdl2
             SDL_SysWMinfo wmInfo;
             SDL_GetVersion(&wmInfo.version);
             SDL_GetWMWindowInfo(_window, &wmInfo);
-            if (wmInfo.subsystem == SysWMType.Windows)
+            switch (wmInfo.subsystem)
             {
-                Win32WindowInfo win32Info = Unsafe.Read<Win32WindowInfo>(&wmInfo.info);
-                return win32Info.Sdl2Window;
+                case SysWMType.Windows:
+                    Win32WindowInfo win32Info = Unsafe.Read<Win32WindowInfo>(&wmInfo.info);
+                    return win32Info.window;
+                case SysWMType.X11:
+                    X11WindowInfo x11Info = Unsafe.Read<X11WindowInfo>(&wmInfo.info);
+                    return x11Info.window;
+                case SysWMType.Wayland:
+                    WaylandWindowInfo waylandInfo = Unsafe.Read<WaylandWindowInfo>(&wmInfo.info);
+                    return waylandInfo.surface;
+                case SysWMType.Cocoa:
+                    CocoaWindowInfo cocoaInfo = Unsafe.Read<CocoaWindowInfo>(&wmInfo.info);
+                    return cocoaInfo.window;
+                case SysWMType.Android:
+                    AndroidWindowInfo androidInfo = Unsafe.Read<AndroidWindowInfo>(&wmInfo.info);
+                    return androidInfo.window;
+                default:
+                    return _window;
             }
-
-            return _window;
         }
 
         private class SimpleInputSnapshot : InputSnapshot

--- a/src/Veldrid.SDL2/Sdl2Window.cs
+++ b/src/Veldrid.SDL2/Sdl2Window.cs
@@ -958,10 +958,10 @@ namespace Veldrid.Sdl2
             {
                 case SysWMType.Windows:
                     Win32WindowInfo win32Info = Unsafe.Read<Win32WindowInfo>(&wmInfo.info);
-                    return win32Info.window;
+                    return win32Info.Sdl2Window;
                 case SysWMType.X11:
                     X11WindowInfo x11Info = Unsafe.Read<X11WindowInfo>(&wmInfo.info);
-                    return x11Info.window;
+                    return x11Info.Sdl2Window;
                 case SysWMType.Wayland:
                     WaylandWindowInfo waylandInfo = Unsafe.Read<WaylandWindowInfo>(&wmInfo.info);
                     return waylandInfo.surface;

--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -146,18 +146,18 @@ namespace Veldrid.StartupUtilities
             {
                 case SysWMType.Windows:
                     Win32WindowInfo w32Info = Unsafe.Read<Win32WindowInfo>(&sysWmInfo.info);
-                    return SwapchainSource.CreateWin32(w32Info.Sdl2Window, w32Info.hinstance);
+                    return SwapchainSource.CreateWin32(w32Info.window, w32Info.hinstance);
                 case SysWMType.X11:
                     X11WindowInfo x11Info = Unsafe.Read<X11WindowInfo>(&sysWmInfo.info);
                     return SwapchainSource.CreateXlib(
                         x11Info.display,
-                        x11Info.Sdl2Window);
+                        x11Info.window);
                 case SysWMType.Wayland:
                     WaylandWindowInfo wlInfo = Unsafe.Read<WaylandWindowInfo>(&sysWmInfo.info);
                     return SwapchainSource.CreateWayland(wlInfo.display, wlInfo.surface);
                 case SysWMType.Cocoa:
                     CocoaWindowInfo cocoaInfo = Unsafe.Read<CocoaWindowInfo>(&sysWmInfo.info);
-                    IntPtr nsWindow = cocoaInfo.Window;
+                    IntPtr nsWindow = cocoaInfo.window;
                     return SwapchainSource.CreateNSWindow(nsWindow);
                 default:
                     throw new PlatformNotSupportedException("Cannot create a SwapchainSource for " + sysWmInfo.subsystem + ".");
@@ -230,12 +230,12 @@ namespace Veldrid.StartupUtilities
             {
                 case SysWMType.Windows:
                     Win32WindowInfo w32Info = Unsafe.Read<Win32WindowInfo>(&sysWmInfo.info);
-                    return Vk.VkSurfaceSource.CreateWin32(w32Info.hinstance, w32Info.Sdl2Window);
+                    return Vk.VkSurfaceSource.CreateWin32(w32Info.hinstance, w32Info.window);
                 case SysWMType.X11:
                     X11WindowInfo x11Info = Unsafe.Read<X11WindowInfo>(&sysWmInfo.info);
                     return Vk.VkSurfaceSource.CreateXlib(
                         (Vulkan.Xlib.Display*)x11Info.display,
-                        new Vulkan.Xlib.Window() { Value = x11Info.Sdl2Window });
+                        new Vulkan.Xlib.Window() { Value = x11Info.window });
                 default:
                     throw new PlatformNotSupportedException("Cannot create a Vulkan surface for " + sysWmInfo.subsystem + ".");
             }

--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -146,12 +146,12 @@ namespace Veldrid.StartupUtilities
             {
                 case SysWMType.Windows:
                     Win32WindowInfo w32Info = Unsafe.Read<Win32WindowInfo>(&sysWmInfo.info);
-                    return SwapchainSource.CreateWin32(w32Info.window, w32Info.hinstance);
+                    return SwapchainSource.CreateWin32(w32Info.Sdl2Window, w32Info.hinstance);
                 case SysWMType.X11:
                     X11WindowInfo x11Info = Unsafe.Read<X11WindowInfo>(&sysWmInfo.info);
                     return SwapchainSource.CreateXlib(
                         x11Info.display,
-                        x11Info.window);
+                        x11Info.Sdl2Window);
                 case SysWMType.Wayland:
                     WaylandWindowInfo wlInfo = Unsafe.Read<WaylandWindowInfo>(&sysWmInfo.info);
                     return SwapchainSource.CreateWayland(wlInfo.display, wlInfo.surface);
@@ -230,12 +230,12 @@ namespace Veldrid.StartupUtilities
             {
                 case SysWMType.Windows:
                     Win32WindowInfo w32Info = Unsafe.Read<Win32WindowInfo>(&sysWmInfo.info);
-                    return Vk.VkSurfaceSource.CreateWin32(w32Info.hinstance, w32Info.window);
+                    return Vk.VkSurfaceSource.CreateWin32(w32Info.hinstance, w32Info.Sdl2Window);
                 case SysWMType.X11:
                     X11WindowInfo x11Info = Unsafe.Read<X11WindowInfo>(&sysWmInfo.info);
                     return Vk.VkSurfaceSource.CreateXlib(
                         (Vulkan.Xlib.Display*)x11Info.display,
-                        new Vulkan.Xlib.Window() { Value = x11Info.window });
+                        new Vulkan.Xlib.Window() { Value = x11Info.Sdl2Window });
                 default:
                     throw new PlatformNotSupportedException("Cannot create a Vulkan surface for " + sysWmInfo.subsystem + ".");
             }


### PR DESCRIPTION
Added support for window native pointer and renamed some of the window info variables to reflect the name used in the SDL2 C library. The name was changed because the Sdl2Window suggests it is an SDLWindow pointer instead of the native window pointer.  