### PR TITLE
Allow non square compressed texture update support.

### DIFF
--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -1162,7 +1162,7 @@ namespace Veldrid.OpenGL
             uint blockSize = isCompressed ? 4u : 1u;
 
             uint blockAlignedWidth = Math.Max(width, blockSize);
-            uint blockAlignedHeight = Math.Max(width, blockSize);
+            uint blockAlignedHeight = Math.Max(height, blockSize);
 
             uint rowPitch = FormatHelpers.GetRowPitch(blockAlignedWidth, texture.Format);
             uint depthPitch = FormatHelpers.GetDepthPitch(rowPitch, blockAlignedHeight, texture.Format);


### PR DESCRIPTION
Allow for none square compressed texture update to be supported. The OpenSage is crashing when updating non-square compressed textures. 