### PR TITLE
Removed unused code that issues a GL_INVALID_OPERATION

### DIFF
--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -269,12 +269,7 @@ namespace Veldrid.StartupUtilities
                 }
             }
 
-            int actualDepthSize;
-            int result = Sdl2Native.SDL_GL_GetAttribute(SDL_GLAttribute.DepthSize, &actualDepthSize);
-            int actualStencilSize;
-            result = Sdl2Native.SDL_GL_GetAttribute(SDL_GLAttribute.StencilSize, &actualStencilSize);
-
-            result = Sdl2Native.SDL_GL_SetSwapInterval(options.SyncToVerticalBlank ? 1 : 0);
+            int result = Sdl2Native.SDL_GL_SetSwapInterval(options.SyncToVerticalBlank ? 1 : 0);
 
             OpenGL.OpenGLPlatformInfo platformInfo = new OpenGL.OpenGLPlatformInfo(
                 contextHandle,


### PR DESCRIPTION
In order to use the SDL_GL_GetAttribute, the OpenGL context has to have been created and make current. Which at this point has not been. But the code is never used so it should be removed.