### PR TITLE
Add Opengl shader program Validation

### DIFF
--- a/src/Veldrid.OpenGLBindings/OpenGLNative.cs
+++ b/src/Veldrid.OpenGLBindings/OpenGLNative.cs
@@ -593,6 +593,11 @@ namespace Veldrid.OpenGLBinding
         public static void glUseProgram(uint program) => p_glUseProgram(program);
 
         [UnmanagedFunctionPointer(CallConv)]
+        private delegate void glValidateProgram_t(uint program);
+        private static glValidateProgram_t p_glValidateProgram;
+        public static void glValidateProgram(uint program) => p_glValidateProgram(program);
+
+        [UnmanagedFunctionPointer(CallConv)]
         private delegate void glBindBufferRange_t(
             BufferRangeTarget target,
             uint index,
@@ -1792,6 +1797,7 @@ namespace Veldrid.OpenGLBinding
             LoadFunction("glGetUniformLocation", out p_glGetUniformLocation);
             LoadFunction("glGetAttribLocation", out p_glGetAttribLocation);
             LoadFunction("glUseProgram", out p_glUseProgram);
+            LoadFunction("glValidateProgram", out p_glValidateProgram);
             LoadFunction("glBindBufferRange", out p_glBindBufferRange);
             LoadFunction("glDebugMessageCallback", out p_glDebugMessageCallback);
             LoadFunction("glBufferData", out p_glBufferData);

--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -681,6 +681,8 @@ namespace Veldrid.OpenGL
             glUseProgram(_graphicsPipeline.Program);
             CheckLastError();
 
+            ValidateProgram(_graphicsPipeline.Program);
+
             int vertexStridesCount = _graphicsPipeline.VertexStrides.Length;
             Util.EnsureArrayMinimumSize(ref _vertexBuffers, (uint)vertexStridesCount);
             Util.EnsureArrayMinimumSize(ref _vbOffsets, (uint)vertexStridesCount);
@@ -801,6 +803,8 @@ namespace Veldrid.OpenGL
             // Shader Set
             glUseProgram(_computePipeline.Program);
             CheckLastError();
+
+            ValidateProgram(_graphicsPipeline.Program);
         }
 
         public void SetGraphicsResourceSet(uint slot, ResourceSet rs, uint dynamicOffsetCount, ref uint dynamicOffsets)

--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -681,7 +681,10 @@ namespace Veldrid.OpenGL
             glUseProgram(_graphicsPipeline.Program);
             CheckLastError();
 
-            ValidateProgram(_graphicsPipeline.Program);
+            if (_gd.DebugGL)
+            {
+                OpenGLUtil.ValidateProgram(_graphicsPipeline.Program);
+            }
 
             int vertexStridesCount = _graphicsPipeline.VertexStrides.Length;
             Util.EnsureArrayMinimumSize(ref _vertexBuffers, (uint)vertexStridesCount);
@@ -803,8 +806,10 @@ namespace Veldrid.OpenGL
             // Shader Set
             glUseProgram(_computePipeline.Program);
             CheckLastError();
-
-            ValidateProgram(_graphicsPipeline.Program);
+            if (_gd.DebugGL)
+            {
+                OpenGLUtil.ValidateProgram(_graphicsPipeline.Program);
+            }
         }
 
         public void SetGraphicsResourceSet(uint slot, ResourceSet rs, uint dynamicOffsetCount, ref uint dynamicOffsets)

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -23,6 +23,7 @@ namespace Veldrid.OpenGL
         private string _shadingLanguageVersion;
         private GraphicsApiVersion _apiVersion;
         private GraphicsBackend _backendType;
+        private bool _debugGL;
         private GraphicsDeviceFeatures _features;
         private uint _vao;
         private readonly ConcurrentQueue<OpenGLDeferredResource> _resourcesToDispose
@@ -73,6 +74,8 @@ namespace Veldrid.OpenGL
         public override GraphicsApiVersion ApiVersion => _apiVersion;
 
         public override GraphicsBackend BackendType => _backendType;
+
+        public bool DebugGL { get => _debugGL; internal set => _debugGL = value; }
 
         public override bool IsUvOriginTopLeft => false;
 
@@ -220,6 +223,7 @@ namespace Veldrid.OpenGL
             {
                 EnableDebugCallback();
             }
+            DebugGL = options.Debug;
 
             bool backbufferIsSrgb = ManualSrgbBackbufferQuery();
 

--- a/src/Veldrid/OpenGL/OpenGLPipeline.cs
+++ b/src/Veldrid/OpenGL/OpenGLPipeline.cs
@@ -142,6 +142,8 @@ namespace Veldrid.OpenGL
             glLinkProgram(_program);
             CheckLastError();
 
+            ValidateProgram(_program);
+
 #if DEBUG && GL_VALIDATE_VERTEX_INPUT_ELEMENTS
             slot = 0;
             foreach (VertexLayoutDescription layoutDesc in VertexLayouts)
@@ -180,6 +182,7 @@ namespace Veldrid.OpenGL
                 string log = Encoding.UTF8.GetString(infoLog, (int)bytesWritten);
                 throw new VeldridException($"Error linking GL program: {log}");
             }
+            ValidateProgram(_program);
 
             ProcessResourceSetLayouts(ResourceLayouts);
         }

--- a/src/Veldrid/OpenGL/OpenGLPipeline.cs
+++ b/src/Veldrid/OpenGL/OpenGLPipeline.cs
@@ -141,8 +141,10 @@ namespace Veldrid.OpenGL
 
             glLinkProgram(_program);
             CheckLastError();
-
-            ValidateProgram(_program);
+            if (_gd.DebugGL)
+            {
+                OpenGLUtil.ValidateProgram(_program);
+            }
 
 #if DEBUG && GL_VALIDATE_VERTEX_INPUT_ELEMENTS
             slot = 0;
@@ -182,7 +184,10 @@ namespace Veldrid.OpenGL
                 string log = Encoding.UTF8.GetString(infoLog, (int)bytesWritten);
                 throw new VeldridException($"Error linking GL program: {log}");
             }
-            ValidateProgram(_program);
+            if (_gd.DebugGL)
+            {
+                OpenGLUtil.ValidateProgram(_program);
+            }
 
             ProcessResourceSetLayouts(ResourceLayouts);
         }

--- a/src/Veldrid/OpenGL/OpenGLUtil.cs
+++ b/src/Veldrid/OpenGL/OpenGLUtil.cs
@@ -25,6 +25,30 @@ namespace Veldrid.OpenGL
             }
         }
 
+        [Conditional("DEBUG")]
+        internal unsafe static void ValidateProgram(uint program)
+        {
+            int validateStatus;
+            glGetProgramiv(program, GetProgramParameterName.ValidateStatus, &validateStatus);
+            CheckLastError();
+            if (validateStatus != 1)
+            {
+                if (Debugger.IsAttached)
+                {
+                    Debugger.Break();
+                }
+
+                byte* infoLog = stackalloc byte[4096];
+                uint bytesWritten;
+                glGetProgramInfoLog(program, 4096, &bytesWritten, infoLog);
+                CheckLastError();
+                string log = Encoding.UTF8.GetString(infoLog, (int)bytesWritten);
+                if(bytesWritten == 0)
+                    log = "Unknown";
+                throw new VeldridException($"Error validate GL program: {log}");
+            }
+        }
+
         internal static unsafe void SetObjectLabel(ObjectLabelIdentifier identifier, uint target, string name)
         {
             if (HasGlObjectLabel)

--- a/src/Veldrid/OpenGL/OpenGLUtil.cs
+++ b/src/Veldrid/OpenGL/OpenGLUtil.cs
@@ -28,6 +28,8 @@ namespace Veldrid.OpenGL
         [Conditional("DEBUG")]
         internal unsafe static void ValidateProgram(uint program)
         {
+            glValidateProgram(program);
+
             int validateStatus;
             glGetProgramiv(program, GetProgramParameterName.ValidateStatus, &validateStatus);
             CheckLastError();

--- a/src/Veldrid/OpenGL/OpenGLUtil.cs
+++ b/src/Veldrid/OpenGL/OpenGLUtil.cs
@@ -29,6 +29,7 @@ namespace Veldrid.OpenGL
         internal unsafe static void ValidateProgram(uint program)
         {
             glValidateProgram(program);
+            CheckLastError();
 
             int validateStatus;
             glGetProgramiv(program, GetProgramParameterName.ValidateStatus, &validateStatus);


### PR DESCRIPTION
There has been an issue with OpenSAGE, https://github.com/OpenSAGE/OpenSAGE/issues/389. Where the screen is black. This seems to have been the cause that the OpenGL shader program was in an invalid state and thus never executed probably. This PR adds OpenGL validation before executing the program after lining for Debug build only. This is so it becomes easier to debug.

Though, I don't know if should add some additional options or just disable exception when finding an invalid OpenGL shader program since I don't know if this will cause a lot of programs to crash using veldrid.