### PR TITLE
Add indirect draw indexed entry for OpenGL

### DIFF
--- a/src/Veldrid/OpenGL/NoAllocEntryList/OpenGLNoAllocCommandEntryList.cs
+++ b/src/Veldrid/OpenGL/NoAllocEntryList/OpenGLNoAllocCommandEntryList.cs
@@ -428,6 +428,7 @@ namespace Veldrid.OpenGL.NoAllocEntryList
         public void DrawIndexedIndirect(DeviceBuffer indirectBuffer, uint offset, uint drawCount, uint stride)
         {
             NoAllocDrawIndexedIndirectEntry entry = new NoAllocDrawIndexedIndirectEntry(Track(indirectBuffer), offset, drawCount, stride);
+            AddEntry(DrawIndexedIndirectEntryID, ref entry);
         }
 
         public void Dispatch(uint groupCountX, uint groupCountY, uint groupCountZ)


### PR DESCRIPTION
Making sure that the indirect draw indexed command is recorded for OpenGL.