### PR TITLE
Check Feature Support on OpenGL

### DIFF
--- a/src/Veldrid/OpenGL/OpenGLExtensions.cs
+++ b/src/Veldrid/OpenGL/OpenGLExtensions.cs
@@ -57,6 +57,10 @@ namespace Veldrid.OpenGL
             EXT_DebugMarker = _backend == GraphicsBackend.OpenGLES && IsExtensionSupported("GL_EXT_debug_marker");
 
             ARB_GpuShaderFp64 = GLVersion(4, 0) || IsExtensionSupported("GL_ARB_gpu_shader_fp64");
+
+            GL_ARB_uniform_buffer_object = IsExtensionSupported("GL_ARB_uniform_buffer_object");
+
+            AnisotropicFilter = IsExtensionSupported("GL_EXT_texture_filter_anisotropic") || IsExtensionSupported("GL_ARB_texture_filter_anisotropic");
         }
 
         public readonly bool ARB_DirectStateAccess;
@@ -69,6 +73,7 @@ namespace Veldrid.OpenGL
         public readonly bool EXT_sRGBWriteControl;
         public readonly bool EXT_DebugMarker;
         public readonly bool ARB_GpuShaderFp64;
+        public readonly bool GL_ARB_uniform_buffer_object;
 
         // Differs between GL / GLES
         public readonly bool TextureStorage;
@@ -83,6 +88,7 @@ namespace Veldrid.OpenGL
         public readonly bool DrawIndirect;
         public readonly bool MultiDrawIndirect;
         public readonly bool StorageBuffers;
+        public readonly bool AnisotropicFilter;
 
         /// <summary>
         /// Returns a value indicating whether the given extension is supported.

--- a/src/Veldrid/OpenGL/OpenGLExtensions.cs
+++ b/src/Veldrid/OpenGL/OpenGLExtensions.cs
@@ -58,7 +58,7 @@ namespace Veldrid.OpenGL
 
             ARB_GpuShaderFp64 = GLVersion(4, 0) || IsExtensionSupported("GL_ARB_gpu_shader_fp64");
 
-            GL_ARB_uniform_buffer_object = IsExtensionSupported("GL_ARB_uniform_buffer_object");
+            ARB_uniform_buffer_object = IsExtensionSupported("GL_ARB_uniform_buffer_object");
 
             AnisotropicFilter = IsExtensionSupported("GL_EXT_texture_filter_anisotropic") || IsExtensionSupported("GL_ARB_texture_filter_anisotropic");
         }
@@ -73,7 +73,7 @@ namespace Veldrid.OpenGL
         public readonly bool EXT_sRGBWriteControl;
         public readonly bool EXT_DebugMarker;
         public readonly bool ARB_GpuShaderFp64;
-        public readonly bool GL_ARB_uniform_buffer_object;
+        public readonly bool ARB_uniform_buffer_object;
 
         // Differs between GL / GLES
         public readonly bool TextureStorage;

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -176,7 +176,7 @@ namespace Veldrid.OpenGL
                 structuredBuffer: _extensions.StorageBuffers,
                 subsetTextureView: _extensions.ARB_TextureView,
                 commandListDebugMarkers: _extensions.KHR_Debug || _extensions.EXT_DebugMarker,
-                bufferRangeBinding: _extensions.GL_ARB_uniform_buffer_object,
+                bufferRangeBinding: _extensions.ARB_uniform_buffer_object,
                 shaderFloat64: _extensions.ARB_GpuShaderFp64);
 
             int uboAlignment;

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -169,14 +169,14 @@ namespace Veldrid.OpenGL
                 drawIndirect: drawIndirect,
                 drawIndirectBaseInstance: drawIndirect,
                 fillModeWireframe: _backendType == GraphicsBackend.OpenGL,
-                samplerAnisotropy: true,
+                samplerAnisotropy: _extensions.AnisotropicFilter,
                 depthClipDisable: _backendType == GraphicsBackend.OpenGL,
                 texture1D: _backendType == GraphicsBackend.OpenGL,
                 independentBlend: _extensions.IndependentBlend,
                 structuredBuffer: _extensions.StorageBuffers,
                 subsetTextureView: _extensions.ARB_TextureView,
                 commandListDebugMarkers: _extensions.KHR_Debug || _extensions.EXT_DebugMarker,
-                bufferRangeBinding: true,
+                bufferRangeBinding: _extensions.GL_ARB_uniform_buffer_object,
                 shaderFloat64: _extensions.ARB_GpuShaderFp64);
 
             int uboAlignment;


### PR DESCRIPTION
Added feature check on buffer range binding and anisotropic filtering since they are not guaranteed to be supported on all OpenGL devices.