### PR TITLE
Add constant and slope-scaled depth bias options.

### DIFF
--- a/src/Veldrid.OpenGLBindings/OpenGLNative.cs
+++ b/src/Veldrid.OpenGLBindings/OpenGLNative.cs
@@ -523,6 +523,11 @@ namespace Veldrid.OpenGLBinding
         public static void glPolygonMode(MaterialFace face, PolygonMode mode) => p_glPolygonMode(face, mode);
 
         [UnmanagedFunctionPointer(CallConv)]
+        private delegate void glPolygonOffset_t(float factor, float units);
+        private static glPolygonOffset_t p_glPolygonOffset;
+        public static void glPolygonOffset(float factor, float units) => p_glPolygonOffset(factor, units);
+
+        [UnmanagedFunctionPointer(CallConv)]
         private delegate uint glCreateProgram_t();
         private static glCreateProgram_t p_glCreateProgram;
         public static uint glCreateProgram() => p_glCreateProgram();
@@ -1857,6 +1862,7 @@ namespace Veldrid.OpenGLBinding
             LoadFunction("glDebugMessageInsert", out p_glDebugMessageInsert);
 
             LoadFunction("glReadPixels", out p_glReadPixels);
+            LoadFunction("glPolygonOffset", out p_glPolygonOffset);
 
             if (!gles)
             {

--- a/src/Veldrid/D3D11/D3D11ResourceCache.cs
+++ b/src/Veldrid/D3D11/D3D11ResourceCache.cs
@@ -149,7 +149,10 @@ namespace Veldrid.D3D11
                 DepthClipEnable = key.VeldridDescription.DepthClipEnabled,
                 ScissorEnable = key.VeldridDescription.ScissorTestEnabled,
                 FrontCounterClockwise = key.VeldridDescription.FrontFace == FrontFace.CounterClockwise,
-                MultisampleEnable = key.Multisampled
+                MultisampleEnable = key.Multisampled,
+                DepthBias = key.VeldridDescription.DepthBiasEnabled ? key.VeldridDescription.DepthBiasConstant : 0,
+                SlopeScaledDepthBias = key.VeldridDescription.DepthBiasEnabled ? key.VeldridDescription.DepthBiasSlopeScaled : 0,
+                DepthBiasClamp = 0,
             };
 
             return _device.CreateRasterizerState(rssDesc);

--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -674,6 +674,35 @@ namespace Veldrid.OpenGL
             glFrontFace(OpenGLFormats.VdToGLFrontFaceDirection(rs.FrontFace));
             CheckLastError();
 
+            if (rs.DepthBiasEnabled)
+            {
+                glEnable(EnableCap.PolygonOffsetFill);
+                CheckLastError();
+
+                glEnable(EnableCap.PolygonOffsetLine);
+                CheckLastError();
+
+                glEnable(EnableCap.PolygonOffsetPoint);
+                CheckLastError();
+
+                glPolygonOffset(rs.DepthBiasSlopeScaled, rs.DepthBiasConstant);
+                CheckLastError();
+            }
+            else
+            {
+                glDisable(EnableCap.PolygonOffsetFill);
+                CheckLastError();
+
+                glDisable(EnableCap.PolygonOffsetLine);
+                CheckLastError();
+
+                glDisable(EnableCap.PolygonOffsetPoint);
+                CheckLastError();
+
+                glPolygonOffset(0, 0);
+                CheckLastError();
+            }
+
             // Primitive Topology
             _primitiveType = OpenGLFormats.VdToGLPrimitiveType(_graphicsPipeline.PrimitiveTopology);
 

--- a/src/Veldrid/RasterizerStateDescription.cs
+++ b/src/Veldrid/RasterizerStateDescription.cs
@@ -27,6 +27,18 @@ namespace Veldrid
         /// Controls whether the scissor test is enabled.
         /// </summary>
         public bool ScissorTestEnabled;
+        /// <summary>
+        /// Controls whether depth bias is enabled.
+        /// </summary>
+        public bool DepthBiasEnabled;
+        /// <summary>
+        /// Controls how much constant depth bias to apply.
+        /// </summary>
+        public int DepthBiasConstant;
+        /// <summary>
+        /// Controls how much slope-scaled depth bias to apply.
+        /// </summary>
+        public float DepthBiasSlopeScaled;
 
         /// <summary>
         /// Constructs a new RasterizerStateDescription.
@@ -36,18 +48,27 @@ namespace Veldrid
         /// <param name="frontFace">Controls the winding order used to determine the front face of primitives.</param>
         /// <param name="depthClipEnabled">Controls whether depth clipping is enabled.</param>
         /// <param name="scissorTestEnabled">Controls whether the scissor test is enabled.</param>
+        /// <param name="depthBiasEnabled">Controls whether depth bias is enabled.</param>
+        /// <param name="depthBiasConstant">Controls how much constant depth bias to apply.</param>
+        /// <param name="depthBiasSlope">Controls how much slope-scaled depth bias to apply.</param>
         public RasterizerStateDescription(
             FaceCullMode cullMode,
             PolygonFillMode fillMode,
             FrontFace frontFace,
             bool depthClipEnabled,
-            bool scissorTestEnabled)
+            bool scissorTestEnabled,
+            bool depthBiasEnabled = false,
+            int depthBiasConstant = 0,
+            float depthBiasSlope = 0)
         {
             CullMode = cullMode;
             FillMode = fillMode;
             FrontFace = frontFace;
             DepthClipEnabled = depthClipEnabled;
             ScissorTestEnabled = scissorTestEnabled;
+            DepthBiasEnabled = depthBiasEnabled;
+            DepthBiasSlopeScaled = depthBiasSlope;
+            DepthBiasConstant = depthBiasConstant;
         }
 
         /// <summary>
@@ -59,6 +80,9 @@ namespace Veldrid
         ///     FrontFace = FrontFace.Clockwise
         ///     DepthClipEnabled = true
         ///     ScissorTestEnabled = false
+        ///     DepthBiasEnabled = false
+        ///     DepthBiasSlopeScaled = 0
+        ///     DepthBiasConstant = 0
         /// </summary>
         public static readonly RasterizerStateDescription Default = new RasterizerStateDescription
         {
@@ -67,6 +91,9 @@ namespace Veldrid
             FrontFace = FrontFace.Clockwise,
             DepthClipEnabled = true,
             ScissorTestEnabled = false,
+            DepthBiasEnabled = false,
+            DepthBiasSlopeScaled = 0,
+            DepthBiasConstant = 0,
         };
 
         /// <summary>
@@ -78,6 +105,9 @@ namespace Veldrid
         ///     FrontFace = FrontFace.Clockwise
         ///     DepthClipEnabled = true
         ///     ScissorTestEnabled = false
+        ///     DepthBiasEnabled = false
+        ///     DepthBiasSlopeScaled = 0
+        ///     DepthBiasConstant = 0
         /// </summary>
         public static readonly RasterizerStateDescription CullNone = new RasterizerStateDescription
         {
@@ -86,6 +116,9 @@ namespace Veldrid
             FrontFace = FrontFace.Clockwise,
             DepthClipEnabled = true,
             ScissorTestEnabled = false,
+            DepthBiasEnabled = false,
+            DepthBiasSlopeScaled = 0,
+            DepthBiasConstant = 0,
         };
 
         /// <summary>
@@ -99,7 +132,10 @@ namespace Veldrid
                 && FillMode == other.FillMode
                 && FrontFace == other.FrontFace
                 && DepthClipEnabled.Equals(other.DepthClipEnabled)
-                && ScissorTestEnabled.Equals(other.ScissorTestEnabled);
+                && ScissorTestEnabled.Equals(other.ScissorTestEnabled)
+                && DepthBiasEnabled == other.DepthBiasEnabled
+                && DepthBiasSlopeScaled == other.DepthBiasSlopeScaled
+                && DepthBiasConstant == other.DepthBiasConstant;
         }
 
         /// <summary>
@@ -113,7 +149,10 @@ namespace Veldrid
                 (int)FillMode,
                 (int)FrontFace,
                 DepthClipEnabled.GetHashCode(),
-                ScissorTestEnabled.GetHashCode());
+                ScissorTestEnabled.GetHashCode(),
+                DepthBiasEnabled.GetHashCode(),
+                DepthBiasSlopeScaled.GetHashCode(),
+                DepthBiasConstant.GetHashCode());
         }
     }
 }

--- a/src/Veldrid/Vk/VkPipeline.cs
+++ b/src/Veldrid/Vk/VkPipeline.cs
@@ -77,6 +77,9 @@ namespace Veldrid.Vk
             rsCI.depthClampEnable = !rsDesc.DepthClipEnabled;
             rsCI.frontFace = rsDesc.FrontFace == FrontFace.Clockwise ? VkFrontFace.Clockwise : VkFrontFace.CounterClockwise;
             rsCI.lineWidth = 1f;
+            rsCI.depthBiasEnable = rsDesc.DepthBiasEnabled;
+            rsCI.depthBiasSlopeFactor = rsDesc.DepthBiasEnabled ? rsDesc.DepthBiasSlopeScaled : 0;
+            rsCI.depthBiasConstantFactor = rsDesc.DepthBiasEnabled ? rsDesc.DepthBiasConstant : 0;
 
             pipelineCI.pRasterizationState = &rsCI;
 


### PR DESCRIPTION
Adds depth bias support for all backends, except for Metal. D3D11, Vulkan and OpenGL appear to support it without extensions, and Metal should too, [according to this](https://developer.apple.com/documentation/metal/mtlrendercommandencoder/1516269-setdepthbias).

I haven't added any tests, but it appears to work according to some testing with a hacked-up build of NeoDemo and with my own engine.