### PR TITLE
OperatingSystem.IsAndroid()

### DIFF
--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -8,6 +8,10 @@ using System.Threading;
 using NativeLibraryLoader;
 using Veldrid.MetalBindings;
 
+#if NET5_0_OR_GREATER
+using NativeLibrary = NativeLibraryLoader.NativeLibrary;
+#endif
+
 namespace Veldrid.MTL
 {
     internal unsafe class MTLGraphicsDevice : GraphicsDevice

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -7,6 +7,9 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using NativeLibraryLoader;
 using Veldrid.MetalBindings;
+#if NET5_0
+using NativeLibrary = NativeLibraryLoader.NativeLibrary;
+#endif
 
 namespace Veldrid.MTL
 {

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -7,9 +7,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using NativeLibraryLoader;
 using Veldrid.MetalBindings;
-#if NET5_0
-using NativeLibrary = NativeLibraryLoader.NativeLibrary;
-#endif
 
 namespace Veldrid.MTL
 {

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -5,12 +5,8 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
-using NativeLibraryLoader;
-using Veldrid.MetalBindings;
-
-#if NET5_0_OR_GREATER
 using NativeLibrary = NativeLibraryLoader.NativeLibrary;
-#endif
+using Veldrid.MetalBindings;
 
 namespace Veldrid.MTL
 {

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -1,4 +1,4 @@
-using static Veldrid.OpenGLBinding.OpenGLNative;
+﻿using static Veldrid.OpenGLBinding.OpenGLNative;
 using static Veldrid.OpenGL.OpenGLUtil;
 using System;
 using Veldrid.OpenGLBinding;

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -1,4 +1,4 @@
-﻿using static Veldrid.OpenGLBinding.OpenGLNative;
+using static Veldrid.OpenGLBinding.OpenGLNative;
 using static Veldrid.OpenGL.OpenGLUtil;
 using System;
 using Veldrid.OpenGLBinding;

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -11,9 +11,6 @@ using Veldrid.OpenGL.EAGL;
 using static Veldrid.OpenGL.EGL.EGLNative;
 using NativeLibraryLoader;
 using System.Runtime.CompilerServices;
-#if NET5_0
-using NativeLibrary = NativeLibraryLoader.NativeLibrary;
-#endif
 
 namespace Veldrid.OpenGL
 {

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -12,6 +12,10 @@ using static Veldrid.OpenGL.EGL.EGLNative;
 using NativeLibraryLoader;
 using System.Runtime.CompilerServices;
 
+#if NET5_0_OR_GREATER
+using NativeLibrary = NativeLibraryLoader.NativeLibrary;
+#endif
+
 namespace Veldrid.OpenGL
 {
     internal unsafe class OpenGLGraphicsDevice : GraphicsDevice

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -11,6 +11,9 @@ using Veldrid.OpenGL.EAGL;
 using static Veldrid.OpenGL.EGL.EGLNative;
 using NativeLibraryLoader;
 using System.Runtime.CompilerServices;
+#if NET5_0
+using NativeLibrary = NativeLibraryLoader.NativeLibrary;
+#endif
 
 namespace Veldrid.OpenGL
 {

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -9,12 +9,8 @@ using System.Diagnostics;
 using System.Threading;
 using Veldrid.OpenGL.EAGL;
 using static Veldrid.OpenGL.EGL.EGLNative;
-using NativeLibraryLoader;
-using System.Runtime.CompilerServices;
-
-#if NET5_0_OR_GREATER
 using NativeLibrary = NativeLibraryLoader.NativeLibrary;
-#endif
+using System.Runtime.CompilerServices;
 
 namespace Veldrid.OpenGL
 {

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>$(BinDir)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn Condition="'$(Configuration)' == 'Debug'">1591</NoWarn>

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net5;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>$(BinDir)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn Condition="'$(Configuration)' == 'Debug'">1591</NoWarn>

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>$(BinDir)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn Condition="'$(Configuration)' == 'Debug'">1591</NoWarn>

--- a/src/Veldrid/Vk/VkGraphicsDevice.cs
+++ b/src/Veldrid/Vk/VkGraphicsDevice.cs
@@ -468,11 +468,7 @@ namespace Veldrid.Vk
                     _surfaceExtensions.Add(CommonStrings.VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
                 }
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-                #if NET5_0
-                || OperatingSystem.IsAndroid()
-                #endif
-                )
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 if (availableInstanceExtensions.Contains(CommonStrings.VK_KHR_ANDROID_SURFACE_EXTENSION_NAME))
                 {

--- a/src/Veldrid/Vk/VkGraphicsDevice.cs
+++ b/src/Veldrid/Vk/VkGraphicsDevice.cs
@@ -468,7 +468,11 @@ namespace Veldrid.Vk
                     _surfaceExtensions.Add(CommonStrings.VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
                 }
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            else if (
+                #if NET5_0_OR_GREATER
+                OperatingSystem.IsAndroid() ||
+                #endif
+                RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 if (availableInstanceExtensions.Contains(CommonStrings.VK_KHR_ANDROID_SURFACE_EXTENSION_NAME))
                 {
@@ -1320,6 +1324,12 @@ namespace Veldrid.Vk
             {
                 return instanceExtensions.Contains(CommonStrings.VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
             }
+            #if NET5_0_OR_GREATER
+            else if (OperatingSystem.IsAndroid())
+            {
+                return instanceExtensions.Contains(CommonStrings.VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
+            }
+            #endif
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 if (RuntimeInformation.OSDescription.Contains("Unix")) // Android

--- a/src/Veldrid/Vk/VkGraphicsDevice.cs
+++ b/src/Veldrid/Vk/VkGraphicsDevice.cs
@@ -468,7 +468,11 @@ namespace Veldrid.Vk
                     _surfaceExtensions.Add(CommonStrings.VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
                 }
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                #if NET5_0
+                || OperatingSystem.IsAndroid()
+                #endif
+                )
             {
                 if (availableInstanceExtensions.Contains(CommonStrings.VK_KHR_ANDROID_SURFACE_EXTENSION_NAME))
                 {


### PR DESCRIPTION
Adds NET 5.0 target framework

uses `OperatingSystem.IsAndroid` for android checks