### PR TITLE
[OpenGL] Make mapping buffer coherent

### DIFF
--- a/src/Veldrid/OpenGL/OpenGLFormats.cs
+++ b/src/Veldrid/OpenGL/OpenGLFormats.cs
@@ -576,7 +576,7 @@ namespace Veldrid.OpenGL
                 case MapMode.Read:
                     return BufferAccessMask.Read;
                 case MapMode.Write:
-                    return BufferAccessMask.Write | BufferAccessMask.InvalidateBuffer;
+                    return BufferAccessMask.Write | BufferAccessMask.InvalidateBuffer | BufferAccessMask.Coherent;
                 case MapMode.ReadWrite:
                     return BufferAccessMask.Read | BufferAccessMask.Write;
                 default:


### PR DESCRIPTION
Not marking Write-only buffers as Persistent/Coherent created massive overhead on AMD and Nvidia cards. 
Either mapping or unmapping (depending on vendor) caused massive performance degradation.

Before fix: mapping/unmapping a 64MB buffer blocked the OpenGL thread for ~50ms.
After fix: Specifying `BufferAccessMask.Coherent` when mapping results in performance comparable to Vulkan and DX11. 