### PR TITLE
[Vulkan] fix vkDescriptorPool thread unsafety issue

### DIFF
--- a/src/Veldrid/Vk/VkDescriptorPoolManager.cs
+++ b/src/Veldrid/Vk/VkDescriptorPoolManager.cs
@@ -20,15 +20,18 @@ namespace Veldrid.Vk
 
         public unsafe DescriptorAllocationToken Allocate(DescriptorResourceCounts counts, VkDescriptorSetLayout setLayout)
         {
-            VkDescriptorPool pool = GetPool(counts);
-            VkDescriptorSetAllocateInfo dsAI = VkDescriptorSetAllocateInfo.New();
-            dsAI.descriptorSetCount = 1;
-            dsAI.pSetLayouts = &setLayout;
-            dsAI.descriptorPool = pool;
-            VkResult result = vkAllocateDescriptorSets(_gd.Device, ref dsAI, out VkDescriptorSet set);
-            VulkanUtil.CheckResult(result);
+            lock (_lock)
+            {
+                VkDescriptorPool pool = GetPool(counts);
+                VkDescriptorSetAllocateInfo dsAI = VkDescriptorSetAllocateInfo.New();
+                dsAI.descriptorSetCount = 1;
+                dsAI.pSetLayouts = &setLayout;
+                dsAI.descriptorPool = pool;
+                VkResult result = vkAllocateDescriptorSets(_gd.Device, ref dsAI, out VkDescriptorSet set);
+                VulkanUtil.CheckResult(result);
 
-            return new DescriptorAllocationToken(set, pool);
+                return new DescriptorAllocationToken(set, pool);
+            }
         }
 
         public void Free(DescriptorAllocationToken token, DescriptorResourceCounts counts)

--- a/src/Veldrid/Vk/VulkanUtil.cs
+++ b/src/Veldrid/Vk/VulkanUtil.cs
@@ -277,6 +277,13 @@ namespace Veldrid.Vk
                 srcStageFlags = VkPipelineStageFlags.Transfer;
                 dstStageFlags = VkPipelineStageFlags.LateFragmentTests;
             }
+            else if (oldLayout == VkImageLayout.PresentSrcKHR && newLayout == VkImageLayout.TransferSrcOptimal)
+            {
+                barrier.srcAccessMask = VkAccessFlags.MemoryRead;
+                barrier.dstAccessMask = VkAccessFlags.TransferRead;
+                srcStageFlags = VkPipelineStageFlags.BottomOfPipe;
+                dstStageFlags = VkPipelineStageFlags.Transfer;
+            }
             else
             {
                 Debug.Fail("Invalid image layout transition.");


### PR DESCRIPTION
vkDescriptorPool guards free's and resource tracking with a lock but doesn't guard the actual allocation of memory.

To illustrate this, run something like this from the NeoDemo sample (with preferred backend set to Vk). It should crash with undefined behaviour within a minute (usually a false 'pool out of memory' error). After this lock is added it will no longer crash.

`
void CrashMe()
    {

	   void ThreadProc()
            {

                ResourceLayout rl = _gd.ResourceFactory.CreateResourceLayout(
                    new ResourceLayoutDescription(
                        new ResourceLayoutElementDescription("sampler" + System.Threading.Thread.CurrentThread.ManagedThreadId.ToString(),
                        ResourceKind.Sampler, ShaderStages.Fragment)));

                while (true)
                {
                    Console.WriteLine($"{System.Threading.Thread.CurrentThread.ManagedThreadId} creating rset");
                    _gd.ResourceFactory.CreateResourceSet(new ResourceSetDescription(rl, _gd.PointSampler)).Dispose();
                }

            }

            System.Threading.Thread WorkerThread = new System.Threading.Thread(ThreadProc);
            WorkerThread.Start();

            for (var i = 0; i < 25; i++)
            {
               new System.Threading.Thread(ThreadProc).Start();

            }
            WorkerThread.Join();

	}

`