### PR TITLE
[Vulkan] Add a custom equality comparer for ResourceRefCount

### DIFF
--- a/src/Veldrid/Vk/ResourceRefCount.cs
+++ b/src/Veldrid/Vk/ResourceRefCount.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace Veldrid.Vk
@@ -35,6 +36,29 @@ namespace Veldrid.Vk
             }
 
             return ret;
+        }
+
+        public class EqualityComparer : IEqualityComparer<ResourceRefCount>
+        {
+            public bool Equals(ResourceRefCount x, ResourceRefCount y)
+            {
+                if (x != null && y != null)
+                {
+                    return x.Equals(y);
+                }
+
+                return false;
+            }
+
+            public int GetHashCode(ResourceRefCount obj)
+            {
+                if (obj == null)
+                {
+                    return 0;
+                }
+
+                return obj.GetHashCode ();
+            }
         }
     }
 }

--- a/src/Veldrid/Vk/ResourceRefCount.cs
+++ b/src/Veldrid/Vk/ResourceRefCount.cs
@@ -57,7 +57,7 @@ namespace Veldrid.Vk
                     return 0;
                 }
 
-                return obj.GetHashCode ();
+                return obj.GetHashCode();
             }
         }
     }

--- a/src/Veldrid/Vk/VkCommandList.cs
+++ b/src/Veldrid/Vk/VkCommandList.cs
@@ -1293,7 +1293,7 @@ namespace Veldrid.Vk
         private class StagingResourceInfo
         {
             public List<VkBuffer> BuffersUsed { get; } = new List<VkBuffer>();
-            public HashSet<ResourceRefCount> Resources { get; } = new HashSet<ResourceRefCount>();
+            public HashSet<ResourceRefCount> Resources { get; } = new HashSet<ResourceRefCount>(new ResourceRefCount.EqualityComparer());
             public void Clear()
             {
                 BuffersUsed.Clear();


### PR DESCRIPTION
I can't actually remember what this fixed now. It was either allocations or some unnecessary performance impact - probably allocations, but it was definitely some issue I noticed while working on a project of mine.