### PR TITLE
Partial fix for issue https://github.com/mellinoe/veldrid/issues/411

### DIFF
--- a/src/Veldrid/Vk/VkDeviceMemoryManager.cs
+++ b/src/Veldrid/Vk/VkDeviceMemoryManager.cs
@@ -31,7 +31,7 @@ namespace Veldrid.Vk
         {
             _device = device;
             _physicalDevice = physicalDevice;
-            _bufferImageGranularity = bufferImageGranularity;
+            _bufferImageGranularity = Math.Max(4, bufferImageGranularity);
             _getBufferMemoryRequirements2 = getBufferMemoryRequirements2;
             _getImageMemoryRequirements2 = getImageMemoryRequirements2;
         }


### PR DESCRIPTION
Fix a chunk fragmentation issue caused by small bufferImageGranularity limits for some GPUs

This prevents GPUs with a _bufferImageGranularity limit lower than 4 from fragmenting allocator free chunks