### PR TITLE
Add support for creating swapchains on WinUI 3 based applications

### DIFF
--- a/src/Veldrid/D3D11/D3D11Buffer.cs
+++ b/src/Veldrid/D3D11/D3D11Buffer.cs
@@ -38,7 +38,7 @@ namespace Veldrid.D3D11
             Vortice.Direct3D11.BufferDescription bd = new Vortice.Direct3D11.BufferDescription(
                 (int)sizeInBytes,
                 D3D11Formats.VdToD3D11BindFlags(usage),
-                Vortice.Direct3D11.Usage.Default);
+                Vortice.Direct3D11.ResourceUsage.Default);
             if ((usage & BufferUsage.StructuredBufferReadOnly) == BufferUsage.StructuredBufferReadOnly
                 || (usage & BufferUsage.StructuredBufferReadWrite) == BufferUsage.StructuredBufferReadWrite)
             {
@@ -59,12 +59,12 @@ namespace Veldrid.D3D11
 
             if ((usage & BufferUsage.Dynamic) == BufferUsage.Dynamic)
             {
-                bd.Usage = Vortice.Direct3D11.Usage.Dynamic;
+                bd.Usage = Vortice.Direct3D11.ResourceUsage.Dynamic;
                 bd.CpuAccessFlags = CpuAccessFlags.Write;
             }
             else if ((usage & BufferUsage.Staging) == BufferUsage.Staging)
             {
-                bd.Usage = Vortice.Direct3D11.Usage.Staging;
+                bd.Usage = Vortice.Direct3D11.ResourceUsage.Staging;
                 bd.CpuAccessFlags = CpuAccessFlags.Read | CpuAccessFlags.Write;
             }
 

--- a/src/Veldrid/D3D11/D3D11Formats.cs
+++ b/src/Veldrid/D3D11/D3D11Formats.cs
@@ -399,15 +399,15 @@ namespace Veldrid.D3D11
                 case StencilOperation.Replace:
                     return Vortice.Direct3D11.StencilOperation.Replace;
                 case StencilOperation.IncrementAndClamp:
-                    return Vortice.Direct3D11.StencilOperation.IncrSat;
+                    return Vortice.Direct3D11.StencilOperation.IncrementSaturate;
                 case StencilOperation.DecrementAndClamp:
-                    return Vortice.Direct3D11.StencilOperation.DecrSat;
+                    return Vortice.Direct3D11.StencilOperation.DecrementSaturate;
                 case StencilOperation.Invert:
-                    return Vortice.Direct3D11.StencilOperation.InverseErt;
+                    return Vortice.Direct3D11.StencilOperation.Invert;
                 case StencilOperation.IncrementAndWrap:
-                    return Vortice.Direct3D11.StencilOperation.Incr;
+                    return Vortice.Direct3D11.StencilOperation.Increment;
                 case StencilOperation.DecrementAndWrap:
-                    return Vortice.Direct3D11.StencilOperation.Decr;
+                    return Vortice.Direct3D11.StencilOperation.Decrement;
                 default:
                     throw Illegal.Value<StencilOperation>();
             }

--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -10,6 +10,7 @@ using Vortice.Mathematics;
 using Vortice.Direct3D11.Debug;
 using VorticeDXGI = Vortice.DXGI.DXGI;
 using VorticeD3D11 = Vortice.Direct3D11.D3D11;
+using Vortice.DXGI.Debug;
 
 namespace Veldrid.D3D11
 {
@@ -675,7 +676,7 @@ namespace Veldrid.D3D11
                 // Report live objects using DXGI if available (DXGIGetDebugInterface1 will fail on pre Windows 8 OS).
                 if (VorticeDXGI.DXGIGetDebugInterface1(out IDXGIDebug1 dxgiDebug).Success)
                 {
-                    dxgiDebug.ReportLiveObjects(VorticeDXGI.All, ReportLiveObjectFlags.Summary | ReportLiveObjectFlags.IgnoreInternal);
+                    dxgiDebug.ReportLiveObjects(VorticeDXGI.DebugAll, ReportLiveObjectFlags.Summary | ReportLiveObjectFlags.IgnoreInternal);
                     dxgiDebug.Dispose();
                 }
             }

--- a/src/Veldrid/D3D11/D3D11Swapchain.cs
+++ b/src/Veldrid/D3D11/D3D11Swapchain.cs
@@ -141,6 +141,49 @@ namespace Veldrid.D3D11
                     }
                 }
             }
+            else if (description.Source is WinUISwapchainSource winuiSource)
+            {
+                _pixelScale = winuiSource.LogicalDpi / 96.0f;
+
+                // Properties of the swap chain
+                SwapChainDescription1 swapChainDescription = new SwapChainDescription1()
+                {
+                    AlphaMode = AlphaMode.Ignore,
+                    BufferCount = 2,
+                    Format = _colorFormat,
+                    Height = (int)(description.Height * _pixelScale),
+                    Width = (int)(description.Width * _pixelScale),
+                    SampleDescription = new SampleDescription(1, 0),
+                    SwapEffect = SwapEffect.FlipSequential,
+                    Usage = Vortice.DXGI.Usage.RenderTargetOutput,
+                };
+
+                // Get the Vortice.DXGI factory automatically created when initializing the Direct3D device.
+                using (IDXGIFactory2 dxgiFactory = _gd.Adapter.GetParent<IDXGIFactory2>())
+                {
+                    // Create the swap chain and get the highest version available.
+                    using (IDXGISwapChain1 swapChain1 = dxgiFactory.CreateSwapChainForComposition(_gd.Device, swapChainDescription))
+                    {
+                        _dxgiSwapChain = swapChain1.QueryInterface<IDXGISwapChain2>();
+                    }
+                }
+
+                ComObject co = new ComObject(winuiSource.SwapChainPanelNative);
+
+                Vortice.WinUI.ISwapChainPanelNative swapchainPanelNative = co.QueryInterfaceOrNull<Vortice.WinUI.ISwapChainPanelNative>();
+                if (swapchainPanelNative != null)
+                {
+                    swapchainPanelNative.SetSwapChain(_dxgiSwapChain);
+                }
+                else
+                {
+                    ISwapChainBackgroundPanelNative bgPanelNative = co.QueryInterfaceOrNull<ISwapChainBackgroundPanelNative>();
+                    if (bgPanelNative != null)
+                    {
+                        bgPanelNative.SetSwapChain(_dxgiSwapChain);
+                    }
+                }
+            }
 
             Resize(description.Width, description.Height);
         }

--- a/src/Veldrid/D3D11/D3D11Texture.cs
+++ b/src/Veldrid/D3D11/D3D11Texture.cs
@@ -43,7 +43,7 @@ namespace Veldrid.D3D11
             TypelessDxgiFormat = D3D11Formats.GetTypelessFormat(DxgiFormat);
 
             CpuAccessFlags cpuFlags = CpuAccessFlags.None;
-            Usage resourceUsage = Vortice.Direct3D11.Usage.Default;
+            ResourceUsage resourceUsage = Vortice.Direct3D11.ResourceUsage.Default;
             BindFlags bindFlags = BindFlags.None;
             ResourceOptionFlags optionFlags = ResourceOptionFlags.None;
 
@@ -66,7 +66,7 @@ namespace Veldrid.D3D11
             if ((description.Usage & TextureUsage.Staging) == TextureUsage.Staging)
             {
                 cpuFlags = CpuAccessFlags.Read | CpuAccessFlags.Write;
-                resourceUsage = Vortice.Direct3D11.Usage.Staging;
+                resourceUsage = Vortice.Direct3D11.ResourceUsage.Staging;
             }
 
             if ((description.Usage & TextureUsage.GenerateMipmaps) != 0)

--- a/src/Veldrid/SwapchainSource.cs
+++ b/src/Veldrid/SwapchainSource.cs
@@ -34,6 +34,18 @@ namespace Veldrid
             => new UwpSwapchainSource(swapChainPanel, logicalDpi);
 
         /// <summary>
+        /// Creates a new SwapchainSource for a WinUI 3 SwapChain panel.
+        /// </summary>
+        /// <param name="swapChainPanel">A COM object which must implement the <see cref="Vortice.DXGI.ISwapChainPanelNative"/>
+        /// or <see cref="Vortice.DXGI.ISwapChainBackgroundPanelNative"/> interface. Generally, this should be a SwapChainPanel
+        /// or SwapChainBackgroundPanel contained in your application window.</param>
+        /// <param name="logicalDpi">The logical DPI of the swapchain panel.</param>
+        /// <returns>A new SwapchainSource which can be used to create a <see cref="Swapchain"/> for the given WinUI 3 panel.
+        /// </returns>
+        public static SwapchainSource CreateWinUI(object swapChainPanel, float logicalDpi)
+                => new WinUISwapchainSource(swapChainPanel, logicalDpi);
+
+        /// <summary>
         /// Creates a new SwapchainSource from the given Xlib information.
         /// </summary>
         /// <param name="display">An Xlib Display.</param>
@@ -107,6 +119,18 @@ namespace Veldrid
         public float LogicalDpi { get; }
 
         public UwpSwapchainSource(object swapChainPanelNative, float logicalDpi)
+        {
+            SwapChainPanelNative = swapChainPanelNative;
+            LogicalDpi = logicalDpi;
+        }
+    }
+
+    internal class WinUISwapchainSource : SwapchainSource
+    {
+        public object SwapChainPanelNative { get; }
+        public float LogicalDpi { get; }
+
+        public WinUISwapchainSource(object swapChainPanelNative, float logicalDpi)
         {
             SwapChainPanelNative = swapChainPanelNative;
             LogicalDpi = logicalDpi;

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -23,6 +23,7 @@
 
     <PackageReference Include="Vortice.D3DCompiler" Version="1.9.143" Condition="'$(ExcludeD3D11)' != 'true'" />
     <PackageReference Include="Vortice.Direct3D11" Version="1.9.143" Condition="'$(ExcludeD3D11)' != 'true'" />
+    <PackageReference Include="Vortice.WinUI" Version="1.9.143" />
 
     <ProjectReference Include="..\Veldrid.MetalBindings\Veldrid.MetalBindings.csproj" Condition="'$(ExcludeMetal)' != 'true'" />
 

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -21,8 +21,8 @@
 
     <PackageReference Include="Vk" Version="1.0.25" Condition="'$(ExcludeVulkan)' != 'true'" />
 
-    <PackageReference Include="Vortice.D3DCompiler" Version="1.9.56" Condition="'$(ExcludeD3D11)' != 'true'" />
-    <PackageReference Include="Vortice.Direct3D11" Version="1.9.56" Condition="'$(ExcludeD3D11)' != 'true'" />
+    <PackageReference Include="Vortice.D3DCompiler" Version="1.9.143" Condition="'$(ExcludeD3D11)' != 'true'" />
+    <PackageReference Include="Vortice.Direct3D11" Version="1.9.143" Condition="'$(ExcludeD3D11)' != 'true'" />
 
     <ProjectReference Include="..\Veldrid.MetalBindings\Veldrid.MetalBindings.csproj" Condition="'$(ExcludeMetal)' != 'true'" />
 


### PR DESCRIPTION
Setting xaml SwapChain panel has changed from UWP to WinUI 3. You now need to use interface Vortice.WinUI.ISwapChainPanelNative for it to work. 

This pull request updates Vortice to latest stable (as current version doens't have Vortice.WinUI package) and adds new function to create SwapChainSource on WinUI 3 projects.