### PR TITLE
Update ImageSharp to 1.0.4

### DIFF
--- a/src/Veldrid.ImageSharp/Veldrid.ImageSharp.csproj
+++ b/src/Veldrid.ImageSharp/Veldrid.ImageSharp.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Veldrid\Veldrid.csproj" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-rc0002" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This fixes a bug where Veldrid.ImageSharp would not load the entirety of a texture (only the first few rows of pixels).