### PR TITLE
Allow using external `CAMetalLayer`s in Metal and Vulkan

### DIFF
--- a/src/Veldrid.MetalBindings/CALayer.cs
+++ b/src/Veldrid.MetalBindings/CALayer.cs
@@ -6,6 +6,8 @@ namespace Veldrid.MetalBindings
     public struct CALayer
     {
         public readonly IntPtr NativePtr;
+        public static implicit operator IntPtr(CALayer c) => c.NativePtr;
+
         public CALayer(IntPtr ptr) => NativePtr = ptr;
 
         public void addSublayer(IntPtr layer)

--- a/src/Veldrid.MetalBindings/CAMetalLayer.cs
+++ b/src/Veldrid.MetalBindings/CAMetalLayer.cs
@@ -9,10 +9,20 @@ namespace Veldrid.MetalBindings
 
         public CAMetalLayer(IntPtr ptr) => NativePtr = ptr;
 
-        public static CAMetalLayer New()
+        public static CAMetalLayer New() => s_class.AllocInit<CAMetalLayer>();
+
+        public static bool TryCast(IntPtr layerPointer, out CAMetalLayer metalLayer)
         {
-            var cls = new ObjCClass("CAMetalLayer");
-            return cls.AllocInit<CAMetalLayer>();
+            var layerObject = new NSObject(layerPointer);
+
+            if (layerObject.IsKindOfClass(s_class))
+            {
+                metalLayer = new CAMetalLayer(layerPointer);
+                return true;
+            }
+
+            metalLayer = default;
+            return false;
         }
 
         public MTLDevice device
@@ -59,6 +69,7 @@ namespace Veldrid.MetalBindings
             set => objc_msgSend(NativePtr, "setDisplaySyncEnabled:", value);
         }
 
+        private static readonly ObjCClass s_class = new ObjCClass(nameof(CAMetalLayer));
         private static readonly Selector sel_device = "device";
         private static readonly Selector sel_setDevice = "setDevice:";
         private static readonly Selector sel_pixelFormat = "pixelFormat";

--- a/src/Veldrid.MetalBindings/NSObject.cs
+++ b/src/Veldrid.MetalBindings/NSObject.cs
@@ -1,0 +1,16 @@
+using static Veldrid.MetalBindings.ObjectiveCRuntime;
+using System;
+
+namespace Veldrid.MetalBindings
+{
+    public struct NSObject
+    {
+        public readonly IntPtr NativePtr;
+
+        public NSObject(IntPtr ptr) => NativePtr = ptr;
+
+        public Bool8 IsKindOfClass(IntPtr @class) => bool8_objc_msgSend(NativePtr, sel_isKindOfClass, @class);
+
+        private static readonly Selector sel_isKindOfClass = "isKindOfClass:";
+    }
+}

--- a/src/Veldrid.MetalBindings/NSView.cs
+++ b/src/Veldrid.MetalBindings/NSView.cs
@@ -6,6 +6,8 @@ namespace Veldrid.MetalBindings
     public unsafe struct NSView
     {
         public readonly IntPtr NativePtr;
+        public static implicit operator IntPtr(NSView nsView) => nsView.NativePtr;
+
         public NSView(IntPtr ptr) => NativePtr = ptr;
 
         public Bool8 wantsLayer

--- a/src/Veldrid/MTL/MTLSwapchain.cs
+++ b/src/Veldrid/MTL/MTLSwapchain.cs
@@ -39,8 +39,6 @@ namespace Veldrid.MTL
             _gd = gd;
             _syncToVerticalBlank = description.SyncToVerticalBlank;
 
-            _metalLayer = CAMetalLayer.New();
-
             uint width;
             uint height;
 
@@ -48,12 +46,17 @@ namespace Veldrid.MTL
             if (source is NSWindowSwapchainSource nsWindowSource)
             {
                 NSWindow nswindow = new NSWindow(nsWindowSource.NSWindow);
-                CGSize windowContentSize = nswindow.contentView.frame.size;
+                NSView contentView = nswindow.contentView;
+                CGSize windowContentSize = contentView.frame.size;
                 width = (uint)windowContentSize.width;
                 height = (uint)windowContentSize.height;
-                NSView contentView = nswindow.contentView;
-                contentView.wantsLayer = true;
-                contentView.layer = _metalLayer.NativePtr;
+
+                if (!CAMetalLayer.TryCast(contentView.layer, out _metalLayer))
+                {
+                    _metalLayer = CAMetalLayer.New();
+                    contentView.wantsLayer = true;
+                    contentView.layer = _metalLayer.NativePtr;
+                }
             }
             else if (source is NSViewSwapchainSource nsViewSource)
             {
@@ -61,8 +64,13 @@ namespace Veldrid.MTL
                 CGSize windowContentSize = contentView.frame.size;
                 width = (uint)windowContentSize.width;
                 height = (uint)windowContentSize.height;
-                contentView.wantsLayer = true;
-                contentView.layer = _metalLayer.NativePtr;
+
+                if (!CAMetalLayer.TryCast(contentView.layer, out _metalLayer))
+                {
+                    _metalLayer = CAMetalLayer.New();
+                    contentView.wantsLayer = true;
+                    contentView.layer = _metalLayer.NativePtr;
+                }
             }
             else if (source is UIViewSwapchainSource uiViewSource)
             {
@@ -73,9 +81,14 @@ namespace Veldrid.MTL
                 CGSize viewSize = _uiView.frame.size;
                 width = (uint)(viewSize.width * nativeScale);
                 height = (uint)(viewSize.height * nativeScale);
-                _metalLayer.frame = _uiView.frame;
-                _metalLayer.opaque = true;
-                _uiView.layer.addSublayer(_metalLayer.NativePtr);
+
+                if (!CAMetalLayer.TryCast(_uiView.layer, out _metalLayer))
+                {
+                    _metalLayer = CAMetalLayer.New();
+                    _metalLayer.frame = _uiView.frame;
+                    _metalLayer.opaque = true;
+                    _uiView.layer.addSublayer(_metalLayer.NativePtr);
+                }
             }
             else
             {


### PR DESCRIPTION
Using Veldrid with an external SDL window implementation (not Veldrid's `Sdl2`), SDL provides a ready `NSView`/`UIView` instance with `layer.contentScale` set appropriately for HiDPI support, but Veldrid always creates its own `CAMetalLayer`, potentially ignoring a view's existing metal layer.

Therefore I've changed `VkSurfaceUtil` and `MTLSwapchain` to attempt casting the given view's `CALayer` to `CAMetalLayer` via [`isKindOfClass:`](https://developer.apple.com/documentation/objectivec/1418956-nsobject/1418511-iskindofclass) and use it, otherwise create a new metal layer. (I was hoping something like [`viewWithTag(_:)`](https://developer.apple.com/documentation/appkit/nsview/1483294-viewwithtag) but for classes exists, but alas)

I've also added support for `NSViewSwapchainSource` in Vulkan, as I need that to use SDL's metal-backed view with Vulkan.