### PR TITLE
Add Android Test Project

### DIFF
--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -41,7 +41,17 @@ namespace Veldrid.StartupUtilities
             }
 
             window = CreateWindow(ref windowCI);
-            gd = CreateGraphicsDevice(window, deviceOptions, preferredBackend);
+
+            try
+            {
+                gd = CreateGraphicsDevice(window, deviceOptions, preferredBackend);
+            }
+            catch (Exception)
+            {
+                window.Close();
+                window = null;
+                throw;
+            }
         }
 
 

--- a/src/Veldrid.Tests.Android/AndroidDeviceCreators.cs
+++ b/src/Veldrid.Tests.Android/AndroidDeviceCreators.cs
@@ -1,0 +1,53 @@
+﻿using Android.Views;
+using Xunit;
+
+namespace Veldrid.Tests.Android
+{
+    public abstract class AndroidDeviceCreator : GraphicsDeviceCreator
+    {
+        public static MainActivity? Activity { get; set; }
+
+        public VeldridSurfaceView SurfaceView { get; private set; }
+
+        public GraphicsDevice GraphicsDevice => SurfaceView.GraphicsDevice;
+
+        public AndroidDeviceCreator(GraphicsBackend backend)
+        {
+            Skip.If(!GraphicsDevice.IsBackendSupported(backend));
+            SurfaceView = new VeldridSurfaceView(Activity, backend);
+            var layoutParams = new ViewGroup.LayoutParams(200, 200);
+            ManualResetEventSlim mre = new ManualResetEventSlim(false);
+            SurfaceView.DeviceCreated += mre.Set;
+            Activity.RunOnUiThread(() =>
+            {
+                Activity.AddContentView(SurfaceView, layoutParams);
+            });
+            mre.Wait();
+            SurfaceView.DeviceCreated -= mre.Set;
+            SurfaceView.RunContinuousRenderLoop();
+        }
+
+        public void Dispose()
+        {
+            ManualResetEventSlim mre = new ManualResetEventSlim(false);
+            SurfaceView.DeviceDisposed += mre.Set;
+            Activity.RunOnUiThread(() =>
+            {
+                ((ViewGroup)SurfaceView.Parent).RemoveView(SurfaceView);
+            });
+            mre.Wait();
+            SurfaceView.DeviceDisposed -= mre.Set;
+            SurfaceView.Disable();
+        }
+    }
+
+    public class AndroidOpenGLESDeviceCreator : AndroidDeviceCreator
+    {
+        public AndroidOpenGLESDeviceCreator() : base(GraphicsBackend.OpenGLES) { }
+    }
+
+    public class AndroidVulkanDeviceCreator : AndroidDeviceCreator
+    {
+        public AndroidVulkanDeviceCreator() : base(GraphicsBackend.Vulkan) { }
+    }
+}

--- a/src/Veldrid.Tests.Android/AndroidDeviceCreators.cs
+++ b/src/Veldrid.Tests.Android/AndroidDeviceCreators.cs
@@ -6,15 +6,16 @@ namespace Veldrid.Tests.Android
     {
         public static MainActivity? Activity { get; set; }
 
-        public VeldridSurfaceView SurfaceView { get; private set; }
+        public VeldridSurfaceView SurfaceView { get; }
 
-        public GraphicsDevice GraphicsDevice => SurfaceView.GraphicsDevice;
+        public GraphicsDevice? GraphicsDevice => SurfaceView?.GraphicsDevice;
 
         public AndroidDeviceCreator(GraphicsBackend backend)
         {
             Skip.If(!GraphicsDevice.IsBackendSupported(backend));
-
-            SurfaceView = new VeldridSurfaceView(Activity, backend);
+            if(Activity is null)
+                throw new NullReferenceException(nameof(Activity));
+            SurfaceView = new VeldridSurfaceView(Activity, backend, new GraphicsDeviceOptions() { SwapchainDepthFormat = PixelFormat.R16_UNorm });
             Activity.Paused += SurfaceView.OnPause;
             Activity.Resumed += SurfaceView.OnResume;
             var layoutParams = new RelativeLayout.LayoutParams(10, 10);
@@ -31,9 +32,10 @@ namespace Veldrid.Tests.Android
 
         public void Dispose()
         {
-            SurfaceView.RemoveViewFromActivity(Activity);
-            Activity.Paused -= SurfaceView.OnPause;
-            Activity.Resumed -= SurfaceView.OnResume;
+            var activity = Activity ?? throw new NullReferenceException(nameof(Activity));
+            SurfaceView.RemoveViewFromActivity(activity);
+            activity.Paused -= SurfaceView.OnPause;
+            activity.Resumed -= SurfaceView.OnResume;
         }
     }
 

--- a/src/Veldrid.Tests.Android/AndroidManifest.xml
+++ b/src/Veldrid.Tests.Android/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="Veldrid.Tests.Android" android:versionCode="1" android:versionName="1.0" android:installLocation="preferExternal">
+    <uses-sdk android:minSdkVersion="21" />
+    <application android:allowBackup="true" android:label="@string/app_name"></application>
+</manifest>

--- a/src/Veldrid.Tests.Android/AndroidManifest.xml
+++ b/src/Veldrid.Tests.Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="Veldrid.Tests.Android" android:versionCode="1" android:versionName="1.0" android:installLocation="preferExternal">
     <uses-sdk android:minSdkVersion="21" />
-    <application android:allowBackup="true" android:label="@string/app_name"></application>
+    <application android:allowBackup="true" android:extractNativeLibs="true" android:label="@string/app_name"></application>
 </manifest>

--- a/src/Veldrid.Tests.Android/MainActivity.cs
+++ b/src/Veldrid.Tests.Android/MainActivity.cs
@@ -1,0 +1,47 @@
+using System.Reflection;
+using Android.Content.PM;
+using Xunit;
+using Xunit.Runners.UI;
+using Xunit.Sdk;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+namespace Veldrid.Tests.Android
+{
+    [Activity(
+        Label = "xUnit Android Runner",
+        MainLauncher = true,
+        ConfigurationChanges = ConfigChanges.KeyboardHidden | ConfigChanges.Orientation | ConfigChanges.ScreenSize,
+        Theme = "@android:style/Theme.Material.Light"
+    )]
+    public class MainActivity : RunnerActivity
+    {
+        public MainActivity()
+        {
+            AndroidDeviceCreator.Activity = this;
+        }
+
+        protected override void OnCreate(Bundle bundle)
+        {
+            // tests can be inside the main assembly
+            AddTestAssembly(Assembly.GetExecutingAssembly());
+
+            AddExecutionAssembly(typeof(ExtensibilityPointFactory).Assembly);
+            // or in any reference assemblies
+
+            //AddTestAssembly(typeof(PortableTests).Assembly);
+            // or in any assembly that you load (since JIT is available)
+
+#if false
+            // you can use the default or set your own custom writer (e.g. save to web site and tweet it ;-)
+            Writer = new TcpTextWriter ("10.0.1.2", 16384);
+            // start running the test suites as soon as the application is loaded
+            AutoStart = true;
+            // crash the application (to ensure it's ended) and return to springboard
+            TerminateAfterExecution = true;
+#endif
+            // you cannot add more assemblies once calling base
+            base.OnCreate(bundle);
+        }
+    }
+}

--- a/src/Veldrid.Tests.Android/MainActivity.cs
+++ b/src/Veldrid.Tests.Android/MainActivity.cs
@@ -16,6 +16,10 @@ namespace Veldrid.Tests.Android
     )]
     public class MainActivity : RunnerActivity
     {
+        public delegate void LifecycleHandler();
+        public event LifecycleHandler Paused;
+        public event LifecycleHandler Resumed;
+
         public MainActivity()
         {
             AndroidDeviceCreator.Activity = this;
@@ -42,6 +46,18 @@ namespace Veldrid.Tests.Android
 #endif
             // you cannot add more assemblies once calling base
             base.OnCreate(bundle);
+        }
+
+        protected override void OnPause()
+        {
+            base.OnPause();
+            Paused?.Invoke();
+        }
+
+        protected override void OnResume()
+        {
+            base.OnResume();
+            Resumed?.Invoke();
         }
     }
 }

--- a/src/Veldrid.Tests.Android/MainActivity.cs
+++ b/src/Veldrid.Tests.Android/MainActivity.cs
@@ -17,8 +17,8 @@ namespace Veldrid.Tests.Android
     public class MainActivity : RunnerActivity
     {
         public delegate void LifecycleHandler();
-        public event LifecycleHandler Paused;
-        public event LifecycleHandler Resumed;
+        public event LifecycleHandler? Paused;
+        public event LifecycleHandler? Resumed;
 
         public MainActivity()
         {

--- a/src/Veldrid.Tests.Android/Resources/AboutResources.txt
+++ b/src/Veldrid.Tests.Android/Resources/AboutResources.txt
@@ -1,0 +1,44 @@
+Images, layout descriptions, binary blobs and string dictionaries can be included 
+in your application as resource files.  Various Android APIs are designed to 
+operate on the resource IDs instead of dealing with images, strings or binary blobs 
+directly.
+
+For example, a sample Android app that contains a user interface layout (main.xml),
+an internationalization string table (strings.xml) and some icons (drawable-XXX/icon.png) 
+would keep its resources in the "Resources" directory of the application:
+
+Resources/
+    drawable/
+        icon.png
+
+    layout/
+        main.xml
+
+    values/
+        strings.xml
+
+In order to get the build system to recognize Android resources, set the build action to
+"AndroidResource".  The native Android APIs do not operate directly with filenames, but 
+instead operate on resource IDs.  When you compile an Android application that uses resources, 
+the build system will package the resources for distribution and generate a class called "Resource" 
+(this is an Android convention) that contains the tokens for each one of the resources 
+included. For example, for the above Resources layout, this is what the Resource class would expose:
+
+public class Resource {
+    public class Drawable {
+        public const int icon = 0x123;
+    }
+
+    public class Layout {
+        public const int main = 0x456;
+    }
+
+    public class Strings {
+        public const int first_string = 0xabc;
+        public const int second_string = 0xbcd;
+    }
+}
+
+You would then use Resource.Drawable.icon to reference the drawable/icon.png file, or 
+Resource.Layout.main to reference the layout/main.xml file, or Resource.Strings.first_string 
+to reference the first string in the dictionary file values/strings.xml.

--- a/src/Veldrid.Tests.Android/Resources/layout/activity_main.xml
+++ b/src/Veldrid.Tests.Android/Resources/layout/activity_main.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+</LinearLayout>

--- a/src/Veldrid.Tests.Android/Resources/values/strings.xml
+++ b/src/Veldrid.Tests.Android/Resources/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">Veldrid.Tests.Android</string>
+    <string name="app_text">Hello, Android!</string>
+</resources>

--- a/src/Veldrid.Tests.Android/Tests.cs
+++ b/src/Veldrid.Tests.Android/Tests.cs
@@ -1,0 +1,47 @@
+﻿using Xunit;
+
+namespace Veldrid.Tests.Android
+{
+    [Trait("Backend", "OpenGLES")]
+    public class OpenGLESBufferTests : BufferTestBase<AndroidOpenGLESDeviceCreator> { }
+    [Trait("Backend", "OpenGLES")]
+    public class OpenGLESComputeTests : ComputeTests<AndroidOpenGLESDeviceCreator> { }
+    [Trait("Backend", "OpenGLES")]
+    public class OpenGLESDisposalTests : DisposalTestBase<AndroidOpenGLESDeviceCreator> { }
+    [Trait("Backend", "OpenGLES")]
+    public class OpenGLESFramebufferTests : FramebufferTests<AndroidOpenGLESDeviceCreator> { }
+    [Trait("Backend", "OpenGLES")]
+    public class OpenGLESSwapchainFramebufferTests : SwapchainFramebufferTests<AndroidOpenGLESDeviceCreator> { }
+    [Trait("Backend", "OpenGLES")]
+    public class OpenGLESPipelineTests : PipelineTests<AndroidOpenGLESDeviceCreator> { }
+    [Trait("Backend", "OpenGLES")]
+    public class OpenGLESRenderTests : RenderTests<AndroidOpenGLESDeviceCreator> { }
+    [Trait("Backend", "OpenGLES")]
+    public class OpenGLESResourceSetTests : ResourceSetTests<AndroidOpenGLESDeviceCreator> { }
+    [Trait("Backend", "OpenGLES")]
+    public class OpenGLESTextureTests : TextureTestBase<AndroidOpenGLESDeviceCreator> { }
+    [Trait("Backend", "OpenGLES")]
+    public class OpenGLESVertexLayoutTests : VertexLayoutTests<AndroidOpenGLESDeviceCreator> { }
+
+
+    [Trait("Backend", "Vulkan")]
+    public class VulkanBufferTests : BufferTestBase<AndroidVulkanDeviceCreator> { }
+    [Trait("Backend", "Vulkan")]
+    public class VulkanComputeTests : ComputeTests<AndroidVulkanDeviceCreator> { }
+    [Trait("Backend", "Vulkan")]
+    public class VulkanDisposalTests : DisposalTestBase<AndroidVulkanDeviceCreator> { }
+    [Trait("Backend", "Vulkan")]
+    public class VulkanFramebufferTests : FramebufferTests<AndroidVulkanDeviceCreator> { }
+    [Trait("Backend", "Vulkan")]
+    public class VulkanSwapchainFramebufferTests : SwapchainFramebufferTests<AndroidVulkanDeviceCreator> { }
+    [Trait("Backend", "OpenGLES")]
+    public class VulkanPipelineTests : PipelineTests<AndroidVulkanDeviceCreator> { }
+    [Trait("Backend", "Vulkan")]
+    public class VulkanRenderTests : RenderTests<AndroidVulkanDeviceCreator> { }
+    [Trait("Backend", "Vulkan")]
+    public class VulkanResourceSetTests : ResourceSetTests<AndroidVulkanDeviceCreator> { }
+    [Trait("Backend", "Vulkan")]
+    public class VulkanTextureTests : TextureTestBase<AndroidVulkanDeviceCreator> { }
+    [Trait("Backend", "Vulkan")]
+    public class VulkanVertexLayoutTests : VertexLayoutTests<AndroidVulkanDeviceCreator> { }
+}

--- a/src/Veldrid.Tests.Android/Veldrid.Tests.Android.csproj
+++ b/src/Veldrid.Tests.Android/Veldrid.Tests.Android.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Include="Veldrid.SPIRV" Version="1.0.15-g0381cb1d3b" />
+    <PackageReference Include="Veldrid.SPIRV" Version="$(VeldridSpirvVersion)" />
     <PackageReference Include="Vk" Version="1.0.25" />
     <PackageReference Include="xunit.runner.devices" Version="2.5.25" />
   </ItemGroup>

--- a/src/Veldrid.Tests.Android/Veldrid.Tests.Android.csproj
+++ b/src/Veldrid.Tests.Android/Veldrid.Tests.Android.csproj
@@ -12,6 +12,9 @@
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Veldrid.Tests\Veldrid.Tests.csproj" />
     <ProjectReference Include="..\Veldrid\Veldrid.csproj" />
@@ -26,7 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Include="Veldrid.SPIRV" Version="$(VeldridSpirvVersion)" />
+    <PackageReference Include="Veldrid.SPIRV" Version="1.0.15-g0381cb1d3b" />
     <PackageReference Include="Vk" Version="1.0.25" />
     <PackageReference Include="xunit.runner.devices" Version="2.5.25" />
   </ItemGroup>

--- a/src/Veldrid.Tests.Android/Veldrid.Tests.Android.csproj
+++ b/src/Veldrid.Tests.Android/Veldrid.Tests.Android.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
 
     <ApplicationId>com.companyname.Veldrid.Tests.Android</ApplicationId>

--- a/src/Veldrid.Tests.Android/Veldrid.Tests.Android.csproj
+++ b/src/Veldrid.Tests.Android/Veldrid.Tests.Android.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-android</TargetFramework>
+    <TargetPlatformVersion>31.0</TargetPlatformVersion>
+    <SupportedOSPlatformVersion>25</SupportedOSPlatformVersion>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+
+    <ApplicationId>com.companyname.Veldrid.Tests.Android</ApplicationId>
+    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Veldrid.Tests\Veldrid.Tests.csproj" />
+    <ProjectReference Include="..\Veldrid\Veldrid.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\mipmap-anydpi-v26\" />
+    <Folder Include="Resources\mipmap-hdpi\" />
+    <Folder Include="Resources\mipmap-mdpi\" />
+    <Folder Include="Resources\mipmap-xhdpi\" />
+    <Folder Include="Resources\mipmap-xxhdpi\" />
+    <Folder Include="Resources\mipmap-xxxhdpi\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="Veldrid.SPIRV" Version="$(VeldridSpirvVersion)" />
+    <PackageReference Include="Vk" Version="1.0.25" />
+    <PackageReference Include="xunit.runner.devices" Version="2.5.25" />
+  </ItemGroup>
+</Project>  

--- a/src/Veldrid.Tests.Android/VeldridSurfaceView.cs
+++ b/src/Veldrid.Tests.Android/VeldridSurfaceView.cs
@@ -1,0 +1,156 @@
+﻿using System.Diagnostics;
+using Android.Content;
+using Android.Graphics;
+using Android.Runtime;
+using Android.Views;
+
+namespace Veldrid.Tests.Android
+{
+    public class VeldridSurfaceView : SurfaceView, ISurfaceHolderCallback
+    {
+        private readonly GraphicsBackend _backend;
+        protected GraphicsDeviceOptions DeviceOptions { get; }
+        private bool _surfaceDestroyed;
+        private bool _paused;
+        private bool _enabled;
+        private bool _needsResize;
+        private bool _surfaceCreated;
+
+        public GraphicsDevice GraphicsDevice { get; protected set; }
+        public Swapchain MainSwapchain { get; protected set; }
+
+        public event Action DeviceCreated;
+        public event Action DeviceDisposed;
+        public event Action Resized;
+
+        public VeldridSurfaceView(Context context, GraphicsBackend backend)
+            : this(context, backend, new GraphicsDeviceOptions())
+        {
+        }
+
+        public VeldridSurfaceView(Context context, GraphicsBackend backend, GraphicsDeviceOptions deviceOptions) : base(context)
+        {
+            if (!(backend == GraphicsBackend.Vulkan || backend == GraphicsBackend.OpenGLES))
+            {
+                throw new NotSupportedException($"{backend} is not supported on Android.");
+            }
+
+            _backend = backend;
+            DeviceOptions = deviceOptions;
+            Holder.AddCallback(this);
+        }
+
+        public void Disable()
+        {
+            _enabled = false;
+        }
+
+        public void SurfaceCreated(ISurfaceHolder holder)
+        {
+            bool deviceCreated = false;
+            if (_backend == GraphicsBackend.Vulkan)
+            {
+                if (GraphicsDevice == null)
+                {
+                    GraphicsDevice = GraphicsDevice.CreateVulkan(DeviceOptions);
+                    deviceCreated = true;
+                }
+
+                Debug.Assert(MainSwapchain == null);
+                SwapchainSource ss = SwapchainSource.CreateAndroidSurface(holder.Surface.Handle, JNIEnv.Handle);
+                SwapchainDescription sd = new SwapchainDescription(
+                    ss,
+                    (uint)Width,
+                    (uint)Height,
+                    DeviceOptions.SwapchainDepthFormat,
+                    DeviceOptions.SyncToVerticalBlank);
+                MainSwapchain = GraphicsDevice.ResourceFactory.CreateSwapchain(sd);
+            }
+            else
+            {
+                Debug.Assert(GraphicsDevice == null && MainSwapchain == null);
+                SwapchainSource ss = SwapchainSource.CreateAndroidSurface(holder.Surface.Handle, JNIEnv.Handle);
+                SwapchainDescription sd = new SwapchainDescription(
+                    ss,
+                    (uint)Width,
+                    (uint)Height,
+                    DeviceOptions.SwapchainDepthFormat,
+                    DeviceOptions.SyncToVerticalBlank);
+                GraphicsDevice = GraphicsDevice.CreateOpenGLES(DeviceOptions, sd);
+                MainSwapchain = GraphicsDevice.MainSwapchain;
+                deviceCreated = true;
+            }
+
+            if (deviceCreated)
+            {
+                DeviceCreated?.Invoke();
+            }
+
+            _surfaceCreated = true;
+        }
+
+        public void RunContinuousRenderLoop()
+        {
+            Task.Factory.StartNew(() => RenderLoop(), TaskCreationOptions.LongRunning);
+        }
+
+        public void SurfaceDestroyed(ISurfaceHolder holder)
+        {
+            _surfaceDestroyed = true;
+        }
+
+        public void SurfaceChanged(ISurfaceHolder holder, [GeneratedEnum] Format format, int width, int height)
+        {
+            _needsResize = true;
+        }
+
+        private void RenderLoop()
+        {
+            _enabled = true;
+            while (_enabled)
+            {
+                try
+                {
+                    if (_paused || !_surfaceCreated) { continue; }
+
+                    if (_surfaceDestroyed)
+                    {
+                        HandleSurfaceDestroyed();
+                        continue;
+                    }
+
+                    if (_needsResize)
+                    {
+                        _needsResize = false;
+                        MainSwapchain.Resize((uint)Width, (uint)Height);
+                        Resized?.Invoke();
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.WriteLine("Encountered an error while rendering: " + e);
+                    //throw;
+                }
+            }
+        }
+
+        private void HandleSurfaceDestroyed()
+        {
+            MainSwapchain?.Dispose();
+            MainSwapchain = null;
+            GraphicsDevice?.Dispose();
+            GraphicsDevice = null;
+            DeviceDisposed?.Invoke();
+        }
+
+        public void OnPause()
+        {
+            _paused = true;
+        }
+
+        public void OnResume()
+        {
+            _paused = false;
+        }
+    }
+}

--- a/src/Veldrid.Tests/BufferTests.cs
+++ b/src/Veldrid.Tests/BufferTests.cs
@@ -173,14 +173,8 @@ namespace Veldrid.Tests
         [SkippableFact]
         public void MapThenUpdate_Fails()
         {
-            if (GD.BackendType == GraphicsBackend.Vulkan)
-            {
-                return; // TODO
-            }
-            if (GD.BackendType == GraphicsBackend.Metal)
-            {
-                return; // TODO
-            }
+            Skip.If(GD.BackendType == GraphicsBackend.Vulkan); // TODO
+            Skip.If(GD.BackendType == GraphicsBackend.Metal); // TODO
 
             DeviceBuffer buffer = RF.CreateBuffer(new BufferDescription(1024, BufferUsage.Staging));
             MappedResourceView<int> view = GD.Map<int>(buffer, MapMode.ReadWrite);
@@ -206,14 +200,8 @@ namespace Veldrid.Tests
         [SkippableFact]
         public void Map_DifferentMode_Fails()
         {
-            if (GD.BackendType == GraphicsBackend.Vulkan)
-            {
-                return; // TODO
-            }
-            if (GD.BackendType == GraphicsBackend.Metal)
-            {
-                return; // TODO
-            }
+            Skip.If(GD.BackendType == GraphicsBackend.Vulkan); // TODO
+            Skip.If(GD.BackendType == GraphicsBackend.Metal); // TODO
 
             DeviceBuffer buffer = RF.CreateBuffer(new BufferDescription(1024, BufferUsage.Staging));
             MappedResource map = GD.Map(buffer, MapMode.Read);
@@ -450,11 +438,8 @@ namespace Veldrid.Tests
         [InlineData(BufferUsage.Staging)]
         public void CreateBuffer_UsageFlagsCoverage(BufferUsage usage)
         {
-            if ((usage & BufferUsage.StructuredBufferReadOnly) != 0
-                || (usage & BufferUsage.StructuredBufferReadWrite) != 0)
-            {
-                return;
-            }
+            Skip.If((usage & BufferUsage.StructuredBufferReadOnly) != 0
+                || (usage & BufferUsage.StructuredBufferReadWrite) != 0);
 
             BufferDescription description = new BufferDescription(64, usage);
             if ((usage & BufferUsage.StructuredBufferReadOnly) != 0 || (usage & BufferUsage.StructuredBufferReadWrite) != 0)

--- a/src/Veldrid.Tests/BufferTests.cs
+++ b/src/Veldrid.Tests/BufferTests.cs
@@ -8,7 +8,7 @@ namespace Veldrid.Tests
 {
     public abstract class BufferTestBase<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
     {
-        [Fact]
+        [SkippableFact]
         public void CreateBuffer_Succeeds()
         {
             uint expectedSize = 64;
@@ -20,7 +20,7 @@ namespace Veldrid.Tests
             Assert.Equal(expectedSize, buffer.SizeInBytes);
         }
 
-        [Fact]
+        [SkippableFact]
         public void UpdateBuffer_NonDynamic_Succeeds()
         {
             DeviceBuffer buffer = CreateBuffer(64, BufferUsage.VertexBuffer);
@@ -28,7 +28,7 @@ namespace Veldrid.Tests
             GD.WaitForIdle();
         }
 
-        [Fact]
+        [SkippableFact]
         public void UpdateBuffer_Span_Succeeds()
         {
             DeviceBuffer buffer = CreateBuffer(64, BufferUsage.VertexBuffer);
@@ -37,7 +37,7 @@ namespace Veldrid.Tests
             GD.WaitForIdle();
         }
 
-        [Fact]
+        [SkippableFact]
         public void UpdateBuffer_ThenMapRead_Succeeds()
         {
             DeviceBuffer buffer = CreateBuffer(1024, BufferUsage.Staging);
@@ -51,7 +51,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public unsafe void Staging_Map_WriteThenRead()
         {
             DeviceBuffer buffer = CreateBuffer(256, BufferUsage.Staging);
@@ -71,7 +71,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public void Staging_MapGeneric_WriteThenRead()
         {
             DeviceBuffer buffer = CreateBuffer(1024, BufferUsage.Staging);
@@ -92,7 +92,7 @@ namespace Veldrid.Tests
             GD.Unmap(buffer);
         }
 
-        [Fact]
+        [SkippableFact]
         public void MapGeneric_OutOfBounds_ThrowsIndexOutOfRange()
         {
             DeviceBuffer buffer = CreateBuffer(1024, BufferUsage.Staging);
@@ -101,7 +101,7 @@ namespace Veldrid.Tests
             Assert.Throws<IndexOutOfRangeException>(() => view[-1]);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Map_WrongFlags_Throws()
         {
             DeviceBuffer buffer = CreateBuffer(1024, BufferUsage.VertexBuffer);
@@ -110,7 +110,7 @@ namespace Veldrid.Tests
             Assert.Throws<VeldridException>(() => GD.Map(buffer, MapMode.ReadWrite));
         }
 
-        [Fact]
+        [SkippableFact]
         public void CopyBuffer_Succeeds()
         {
             DeviceBuffer src = CreateBuffer(1024, BufferUsage.Staging);
@@ -134,7 +134,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public void CopyBuffer_Chain_Succeeds()
         {
             DeviceBuffer src = CreateBuffer(1024, BufferUsage.Staging);
@@ -170,7 +170,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public void MapThenUpdate_Fails()
         {
             if (GD.BackendType == GraphicsBackend.Vulkan)
@@ -188,7 +188,7 @@ namespace Veldrid.Tests
             Assert.Throws<VeldridException>(() => GD.UpdateBuffer(buffer, 0, data));
         }
 
-        [Fact]
+        [SkippableFact]
         public void Map_MultipleTimes_Succeeds()
         {
             DeviceBuffer buffer = RF.CreateBuffer(new BufferDescription(1024, BufferUsage.Staging));
@@ -203,7 +203,7 @@ namespace Veldrid.Tests
             GD.Unmap(buffer);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Map_DifferentMode_Fails()
         {
             if (GD.BackendType == GraphicsBackend.Vulkan)
@@ -220,7 +220,7 @@ namespace Veldrid.Tests
             Assert.Throws<VeldridException>(() => GD.Map(buffer, MapMode.Write));
         }
 
-        [Fact]
+        [SkippableFact]
         public unsafe void UnusualSize()
         {
             DeviceBuffer src = RF.CreateBuffer(
@@ -244,7 +244,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public void Update_Dynamic_NonZeroOffset()
         {
             DeviceBuffer dynamic = RF.CreateBuffer(
@@ -282,7 +282,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public void Dynamic_MapRead_Fails()
         {
             DeviceBuffer dynamic = RF.CreateBuffer(
@@ -291,7 +291,7 @@ namespace Veldrid.Tests
             Assert.Throws<VeldridException>(() => GD.Map(dynamic, MapMode.ReadWrite));
         }
 
-        [Fact]
+        [SkippableFact]
         public void CommandList_Update_Staging()
         {
             DeviceBuffer staging = RF.CreateBuffer(
@@ -312,7 +312,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(
             60, BufferUsage.VertexBuffer, 1,
             70, BufferUsage.VertexBuffer, 13,
@@ -364,7 +364,7 @@ namespace Veldrid.Tests
             GD.Unmap(readback);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(BufferUsage.VertexBuffer, 13, 5, 1)]
         [InlineData(BufferUsage.Staging, 13, 5, 1)]
         public void CommandList_UpdateNonStaging_Unaligned(BufferUsage usage, uint bufferSize, uint dataSize, uint offset)
@@ -389,7 +389,7 @@ namespace Veldrid.Tests
             GD.Unmap(readback);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(BufferUsage.UniformBuffer | BufferUsage.Dynamic)]
         [InlineData(BufferUsage.UniformBuffer)]
         [InlineData(BufferUsage.Staging)]
@@ -408,7 +408,7 @@ namespace Veldrid.Tests
             GD.Unmap(readback);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(BufferUsage.UniformBuffer | BufferUsage.Dynamic)]
         [InlineData(BufferUsage.UniformBuffer)]
         [InlineData(BufferUsage.Staging)]
@@ -432,7 +432,7 @@ namespace Veldrid.Tests
             GD.Unmap(readback);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(BufferUsage.UniformBuffer)]
         [InlineData(BufferUsage.UniformBuffer | BufferUsage.Dynamic)]
         [InlineData(BufferUsage.VertexBuffer)]
@@ -466,7 +466,7 @@ namespace Veldrid.Tests
             GD.WaitForIdle();
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(BufferUsage.UniformBuffer)]
         [InlineData(BufferUsage.UniformBuffer | BufferUsage.Dynamic)]
         [InlineData(BufferUsage.VertexBuffer)]
@@ -506,7 +506,7 @@ namespace Veldrid.Tests
             GD.Unmap(readback);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(BufferUsage.UniformBuffer, false)]
         [InlineData(BufferUsage.UniformBuffer, true)]
         [InlineData(BufferUsage.UniformBuffer | BufferUsage.Dynamic, false)]

--- a/src/Veldrid.Tests/ComputeTests.cs
+++ b/src/Veldrid.Tests/ComputeTests.cs
@@ -29,9 +29,11 @@ namespace Veldrid.Tests
 
     public abstract class ComputeTests<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
     {
-        [Fact]
+        [SkippableFact]
         public void ComputeShader3dTexture()
         {
+            Skip.IfNot(GD.Features.ComputeShader);
+
             // Just a dumb compute shader that fills a 3D texture with the same value from a uniform multiplied by the depth.
             string shaderText = @"
 #version 450
@@ -182,13 +184,10 @@ void main()
         }
 
 
-        [Fact]
+        [SkippableFact]
         public void BasicCompute()
         {
-            if (!GD.Features.ComputeShader)
-            {
-                return;
-            }
+            Skip.IfNot(GD.Features.ComputeShader);
 
             ResourceLayout layout = RF.CreateResourceLayout(new ResourceLayoutDescription(
                 new ResourceLayoutElementDescription("Params", ResourceKind.UniformBuffer, ShaderStages.Compute),
@@ -245,12 +244,12 @@ void main()
             GD.Unmap(destinationReadback);
         }
 
-        [Theory]
+        [SkippableTheory]
         [MemberData(nameof(FillBuffer_WithOffsetsData))]
         public void FillBuffer_WithOffsets(uint srcSetMultiple, uint srcBindingMultiple, uint dstSetMultiple, uint dstBindingMultiple, bool combinedLayout)
         {
-            if (!GD.Features.ComputeShader) { return; }
-            if (!GD.Features.BufferRangeBinding && (srcSetMultiple != 0 || srcBindingMultiple != 0 || dstSetMultiple != 0 || dstBindingMultiple != 0)) { return; }
+            Skip.IfNot(GD.Features.ComputeShader);
+            Skip.If(!GD.Features.BufferRangeBinding && (srcSetMultiple != 0 || srcBindingMultiple != 0 || dstSetMultiple != 0 || dstBindingMultiple != 0));
             Debug.Assert((GD.StructuredBufferMinOffsetAlignment % sizeof(uint)) == 0);
 
             uint valueCount = 512;

--- a/src/Veldrid.Tests/DisposalTests.cs
+++ b/src/Veldrid.Tests/DisposalTests.cs
@@ -4,7 +4,7 @@ namespace Veldrid.Tests
 {
     public abstract class DisposalTestBase<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
     {
-        [Fact]
+        [SkippableFact]
         public void Dispose_Buffer()
         {
             DeviceBuffer b = RF.CreateBuffer(new BufferDescription(256, BufferUsage.VertexBuffer));
@@ -12,7 +12,7 @@ namespace Veldrid.Tests
             Assert.True(b.IsDisposed);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Dispose_Texture()
         {
             Texture t = RF.CreateTexture(TextureDescription.Texture2D(1, 1, 1, 1, PixelFormat.R32_G32_B32_A32_Float, TextureUsage.Sampled));
@@ -25,7 +25,7 @@ namespace Veldrid.Tests
             Assert.True(t.IsDisposed);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Dispose_Framebuffer()
         {
             Texture t = RF.CreateTexture(TextureDescription.Texture2D(1, 1, 1, 1, PixelFormat.R32_G32_B32_A32_Float, TextureUsage.RenderTarget));
@@ -38,7 +38,7 @@ namespace Veldrid.Tests
             Assert.True(t.IsDisposed);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Dispose_CommandList()
         {
             CommandList cl = RF.CreateCommandList();
@@ -46,7 +46,7 @@ namespace Veldrid.Tests
             Assert.True(cl.IsDisposed);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Dispose_Sampler()
         {
             Sampler s = RF.CreateSampler(SamplerDescription.Point);
@@ -54,7 +54,7 @@ namespace Veldrid.Tests
             Assert.True(s.IsDisposed);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Dispose_Pipeline()
         {
             Shader[] shaders = TestShaders.LoadVertexFragment(RF, "UIntVertexAttribs");
@@ -95,7 +95,7 @@ namespace Veldrid.Tests
             Assert.True(shaders[1].IsDisposed);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Dispose_ResourceSet()
         {
             ResourceLayout layout = RF.CreateResourceLayout(new ResourceLayoutDescription(

--- a/src/Veldrid.Tests/FramebufferTests.cs
+++ b/src/Veldrid.Tests/FramebufferTests.cs
@@ -5,7 +5,7 @@ namespace Veldrid.Tests
 {
     public abstract class FramebufferTests<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
     {
-        [Fact]
+        [SkippableFact]
         public void NoDepthTarget_ClearAllColors_Succeeds()
         {
             Texture colorTarget = RF.CreateTexture(
@@ -40,7 +40,7 @@ namespace Veldrid.Tests
             GD.Unmap(staging);
         }
 
-        [Fact]
+        [SkippableFact]
         public void NoDepthTarget_ClearDepth_Fails()
         {
             Texture colorTarget = RF.CreateTexture(
@@ -53,7 +53,7 @@ namespace Veldrid.Tests
             Assert.Throws<VeldridException>(() => cl.ClearDepthStencil(1f));
         }
 
-        [Fact]
+        [SkippableFact]
         public void NoColorTarget_ClearColor_Fails()
         {
             Texture depthTarget = RF.CreateTexture(
@@ -66,7 +66,7 @@ namespace Veldrid.Tests
             Assert.Throws<VeldridException>(() => cl.ClearColorTarget(0, RgbaFloat.Red));
         }
 
-        [Fact]
+        [SkippableFact]
         public void ClearColorTarget_OutOfRange_Fails()
         {
             TextureDescription desc = TextureDescription.Texture2D(
@@ -84,7 +84,7 @@ namespace Veldrid.Tests
             Assert.Throws<VeldridException>(() => cl.ClearColorTarget(3, RgbaFloat.Red));
         }
 
-        [Fact]
+        [SkippableFact]
         public void NonZeroMipLevel_ClearColor_Succeeds()
         {
             Texture testTex = RF.CreateTexture(
@@ -136,7 +136,7 @@ namespace Veldrid.Tests
 
     public abstract class SwapchainFramebufferTests<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
     {
-        [Fact]
+        [SkippableFact]
         public void ClearSwapchainFramebuffer_Succeeds()
         {
             CommandList cl = RF.CreateCommandList();

--- a/src/Veldrid.Tests/PipelineTests.cs
+++ b/src/Veldrid.Tests/PipelineTests.cs
@@ -9,7 +9,7 @@ namespace Veldrid.Tests
 {
     public abstract class PipelineTests<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
     {
-        [Fact]
+        [SkippableFact]
         public void CreatePipelines_DifferentInstanceStepRate_Succeeds()
         {
             Texture colorTex = RF.CreateTexture(TextureDescription.Texture2D(1, 1, 1, 1, PixelFormat.R8_G8_B8_A8_UNorm, TextureUsage.RenderTarget));

--- a/src/Veldrid.Tests/Program.cs
+++ b/src/Veldrid.Tests/Program.cs
@@ -1,14 +1,12 @@
 using System;
 using System.Collections.Generic;
-using Veldrid.Tests;
 
 class Program
 {
     static int Main(string[] args)
     {
         List<string> newArgs = new List<string>(args);
-        newArgs.InsertRange(0, new[] { "-parallel", "none" });
-        newArgs.Insert(0, typeof(BufferTestBase<>).Assembly.Location);
+        newArgs.Insert(0, typeof(Program).Assembly.Location);
         int returnCode = Xunit.ConsoleClient.Program.Main(newArgs.ToArray());
         Console.WriteLine("Tests finished. Press any key to exit.");
         if (!Console.IsInputRedirected)

--- a/src/Veldrid.Tests/Program.cs
+++ b/src/Veldrid.Tests/Program.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
+using Veldrid.Tests;
 
 class Program
 {
     static int Main(string[] args)
     {
         List<string> newArgs = new List<string>(args);
-        newArgs.Insert(0, typeof(Program).Assembly.Location);
+        newArgs.InsertRange(0, new[] { "-parallel", "none" });
+        newArgs.Insert(0, typeof(BufferTestBase<>).Assembly.Location);
         int returnCode = Xunit.ConsoleClient.Program.Main(newArgs.ToArray());
         Console.WriteLine("Tests finished. Press any key to exit.");
         if (!Console.IsInputRedirected)

--- a/src/Veldrid.Tests/RenderTests.cs
+++ b/src/Veldrid.Tests/RenderTests.cs
@@ -725,10 +725,7 @@ namespace Veldrid.Tests
         [SkippableFact]
         public void ComputeGeneratedVertices()
         {
-            if (!GD.Features.ComputeShader)
-            {
-                return;
-            }
+            Skip.IfNot(GD.Features.ComputeShader);
 
             uint width = 512;
             uint height = 512;
@@ -862,7 +859,7 @@ namespace Veldrid.Tests
         [InlineData(true)]
         public void SampleTexture1D(bool arrayTexture)
         {
-            if (!GD.Features.Texture1D) { return; }
+            Skip.IfNot(GD.Features.Texture1D);
 
             Texture target = RF.CreateTexture(TextureDescription.Texture2D(
                 50, 50, 1, 1, PixelFormat.R32_G32_B32_A32_Float, TextureUsage.RenderTarget));

--- a/src/Veldrid.Tests/RenderTests.cs
+++ b/src/Veldrid.Tests/RenderTests.cs
@@ -41,7 +41,7 @@ namespace Veldrid.Tests
 
     public abstract class RenderTests<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
     {
-        [Fact]
+        [SkippableFact]
         public void Points_WithUIntColor()
         {
             Texture target = RF.CreateTexture(TextureDescription.Texture2D(
@@ -176,7 +176,7 @@ namespace Veldrid.Tests
             GD.Unmap(staging);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Points_WithUShortNormColor()
         {
             Texture target = RF.CreateTexture(TextureDescription.Texture2D(
@@ -318,7 +318,7 @@ namespace Veldrid.Tests
             return (ushort)(normalizedValue * ushort.MaxValue);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Points_WithUShortColor()
         {
             Texture target = RF.CreateTexture(TextureDescription.Texture2D(
@@ -441,7 +441,7 @@ namespace Veldrid.Tests
             GD.Unmap(staging);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Points_WithFloat16Color()
         {
             Texture target = RF.CreateTexture(TextureDescription.Texture2D(
@@ -594,7 +594,7 @@ namespace Veldrid.Tests
 
         [InlineData(false)]
         [InlineData(true)]
-        [Theory]
+        [SkippableTheory]
         public unsafe void Points_WithTexture_UpdateUnrelated(bool useTextureView)
         {
             // This is a regression test for the case where a user modifies an unrelated texture
@@ -722,7 +722,7 @@ namespace Veldrid.Tests
             GD.Unmap(staging);
         }
 
-        [Fact]
+        [SkippableFact]
         public void ComputeGeneratedVertices()
         {
             if (!GD.Features.ComputeShader)
@@ -791,13 +791,10 @@ namespace Veldrid.Tests
             GD.Unmap(readback);
         }
 
-        [Fact]
+        [SkippableFact]
         public void ComputeGeneratedTexture()
         {
-            if (!GD.Features.ComputeShader)
-            {
-                return;
-            }
+            Skip.IfNot(GD.Features.ComputeShader);
 
             uint width = 4;
             uint height = 1;
@@ -860,7 +857,7 @@ namespace Veldrid.Tests
             GD.Unmap(readback);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(false)]
         [InlineData(true)]
         public void SampleTexture1D(bool arrayTexture)
@@ -926,7 +923,7 @@ namespace Veldrid.Tests
             GD.Unmap(staging);
         }
 
-        [Fact]
+        [SkippableFact]
         public void BindTextureAcrossMultipleDrawCalls()
         {
             Texture target1 = RF.CreateTexture(TextureDescription.Texture2D(
@@ -1047,7 +1044,7 @@ namespace Veldrid.Tests
             GD.Unmap(staging3);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(2, 0)]
         [InlineData(5, 3)]
         [InlineData(32, 31)]
@@ -1111,7 +1108,7 @@ namespace Veldrid.Tests
             GD.Unmap(staging, targetLayer);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(1, 0, 0)]
         [InlineData(1, 0, 3)]
         [InlineData(1, 0, 5)]
@@ -1120,6 +1117,8 @@ namespace Veldrid.Tests
         [InlineData(4, 2, 5)]
         public void RenderToCubemapFace(uint layerCount, uint targetLayer, uint targetFace)
         {
+            if (layerCount > 1)
+                Skip.IfNot(GD.Features.CubeMapArrayTextures);
             Texture target = RF.CreateTexture(TextureDescription.Texture2D(
                 16, 16,
                 1, layerCount,
@@ -1174,6 +1173,7 @@ namespace Veldrid.Tests
 
             Texture staging = GetReadback(target);
             MappedResourceView<RgbaFloat> readView = GD.Map<RgbaFloat>(staging, MapMode.Read, (targetLayer * 6) + targetFace);
+
             for (int x = 0; x < staging.Width; x++)
             {
                 Assert.Equal(RgbaFloat.Pink, readView[x, 0]);
@@ -1181,7 +1181,7 @@ namespace Veldrid.Tests
             GD.Unmap(staging, (targetLayer * 6) + targetFace);
         }
 
-        [Fact]
+        [SkippableFact]
         public void WriteFragmentDepth()
         {
             Texture depthTarget = RF.CreateTexture(

--- a/src/Veldrid.Tests/ResourceSetTests.cs
+++ b/src/Veldrid.Tests/ResourceSetTests.cs
@@ -5,7 +5,7 @@ namespace Veldrid.Tests
 {
     public abstract class ResourceSetTests<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
     {
-        [Fact]
+        [SkippableFact]
         public void ResourceSet_BufferInsteadOfTextureView_Fails()
         {
             ResourceLayout layout = RF.CreateResourceLayout(new ResourceLayoutDescription(
@@ -20,7 +20,7 @@ namespace Veldrid.Tests
             });
         }
 
-        [Fact]
+        [SkippableFact]
         public void ResourceSet_IncorrectTextureUsage_Fails()
         {
             ResourceLayout layout = RF.CreateResourceLayout(new ResourceLayoutDescription(
@@ -35,7 +35,7 @@ namespace Veldrid.Tests
             });
         }
 
-        [Fact]
+        [SkippableFact]
         public void ResourceSet_IncorrectBufferUsage_Fails()
         {
             ResourceLayout layout = RF.CreateResourceLayout(new ResourceLayoutDescription(
@@ -49,7 +49,7 @@ namespace Veldrid.Tests
             });
         }
 
-        [Fact]
+        [SkippableFact]
         public void ResourceSet_TooFewOrTooManyElements_Fails()
         {
             ResourceLayout layout = RF.CreateResourceLayout(new ResourceLayoutDescription(
@@ -80,7 +80,7 @@ namespace Veldrid.Tests
             });
         }
 
-        [Fact]
+        [SkippableFact]
         public void ResourceSet_InvalidUniformOffset_Fails()
         {
             ResourceLayout layout = RF.CreateResourceLayout(new ResourceLayoutDescription(
@@ -101,7 +101,7 @@ namespace Veldrid.Tests
             });
         }
 
-        [Fact]
+        [SkippableFact]
         public void ResourceSet_NoPipelineBound_Fails()
         {
             ResourceLayout layout = RF.CreateResourceLayout(new ResourceLayoutDescription(
@@ -117,7 +117,7 @@ namespace Veldrid.Tests
             cl.End();
         }
 
-        [Fact]
+        [SkippableFact]
         public void ResourceSet_InvalidSlot_Fails()
         {
             DeviceBuffer infoBuffer = RF.CreateBuffer(new BufferDescription(16, BufferUsage.UniformBuffer));
@@ -158,7 +158,7 @@ namespace Veldrid.Tests
             cl.End();
         }
 
-        [Fact]
+        [SkippableFact]
         public void ResourceSet_IncompatibleSet_Fails()
         {
             DeviceBuffer infoBuffer = RF.CreateBuffer(new BufferDescription(16, BufferUsage.UniformBuffer));

--- a/src/Veldrid.Tests/SwapchainTests.cs
+++ b/src/Veldrid.Tests/SwapchainTests.cs
@@ -6,7 +6,7 @@ namespace Veldrid.Tests
 {
     public abstract class SwapchainTests<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
     {
-        [Theory]
+        [SkippableTheory]
         [InlineData(PixelFormat.R16_UNorm, false)]
         [InlineData(PixelFormat.R16_UNorm, true)]
         [InlineData(PixelFormat.R32_Float, false)]
@@ -38,7 +38,7 @@ namespace Veldrid.Tests
 
     public abstract class MainSwapchainTests<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
     {
-        [Fact]
+        [SkippableFact]
         public void Textures_Properties_Correct()
         {
             Texture colorTarget = GD.MainSwapchain.Framebuffer.ColorTargets[0].Target;

--- a/src/Veldrid.Tests/TestShaders.cs
+++ b/src/Veldrid.Tests/TestShaders.cs
@@ -1,16 +1,35 @@
 ﻿using System;
 using System.IO;
+using System.Reflection;
 using Veldrid.SPIRV;
 
 namespace Veldrid.Tests
 {
     internal static class TestShaders
     {
+        private static byte[] ReadResourceBytes(string resourceName)
+        {
+            var names = Assembly.GetExecutingAssembly().GetManifestResourceNames();
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream($"Veldrid.Tests.Shaders.{resourceName}"))
+            {
+                stream.Seek(0, SeekOrigin.End);
+                var len = (int)stream.Position;
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using(var reader = new BinaryReader(stream))
+                {
+                    return reader.ReadBytes(len);
+                }
+            }
+        }
+
+        private static string GetResourceName(string setName, ShaderStages stage) => $"{setName}.{stage.ToString().ToLowerInvariant().Substring(0, 4)}";
+
         public static Shader[] LoadVertexFragment(ResourceFactory factory, string setName)
         {
             return factory.CreateFromSpirv(
-                new ShaderDescription(ShaderStages.Vertex, File.ReadAllBytes(GetPath(setName, ShaderStages.Vertex)), "main"),
-                new ShaderDescription(ShaderStages.Fragment, File.ReadAllBytes(GetPath(setName, ShaderStages.Fragment)), "main"),
+                new ShaderDescription(ShaderStages.Vertex, ReadResourceBytes(GetResourceName(setName, ShaderStages.Vertex)), "main"),
+                new ShaderDescription(ShaderStages.Fragment, ReadResourceBytes(GetResourceName(setName, ShaderStages.Fragment)), "main"),
                 new CrossCompileOptions(false, false, new SpecializationConstant[]
                 {
                     new SpecializationConstant(100, false)
@@ -20,19 +39,11 @@ namespace Veldrid.Tests
         public static Shader LoadCompute(ResourceFactory factory, string setName)
         {
             return factory.CreateFromSpirv(
-                new ShaderDescription(ShaderStages.Compute, File.ReadAllBytes(GetPath(setName, ShaderStages.Compute)), "main"),
+                new ShaderDescription(ShaderStages.Compute, ReadResourceBytes(GetResourceName(setName, ShaderStages.Compute)), "main"),
                 new CrossCompileOptions(false, false, new SpecializationConstant[]
                 {
                     new SpecializationConstant(100, false)
                 }));
-        }
-
-        public static string GetPath(string setName, ShaderStages stage)
-        {
-            return Path.Combine(
-                AppContext.BaseDirectory,
-                "Shaders",
-                $"{setName}.{stage.ToString().ToLowerInvariant().Substring(0, 4)}");
         }
     }
 }

--- a/src/Veldrid.Tests/TextureTests.cs
+++ b/src/Veldrid.Tests/TextureTests.cs
@@ -166,10 +166,7 @@ namespace Veldrid.Tests
         [InlineData(PixelFormat.BC7_UNorm_SRgb, 16, 8, 4, 16, 16)]
         public unsafe void Copy_Compressed_Texture(PixelFormat format, uint blockSizeInBytes, uint srcX, uint srcY, uint copyWidth, uint copyHeight)
         {
-            if (!GD.GetPixelFormatSupport(format, TextureType.Texture2D, TextureUsage.Sampled))
-            {
-                return;
-            }
+            Skip.IfNot(GD.GetPixelFormatSupport(format, TextureType.Texture2D, TextureUsage.Sampled));
 
             Texture copySrc = RF.CreateTexture(TextureDescription.Texture2D(
                 64, 64, 1, 1, format, TextureUsage.Staging));
@@ -218,10 +215,7 @@ namespace Veldrid.Tests
         public unsafe void Copy_Compressed_Array(bool separateLayerCopies)
         {
             PixelFormat format = PixelFormat.BC3_UNorm;
-            if (!GD.GetPixelFormatSupport(format, TextureType.Texture2D, TextureUsage.Sampled))
-            {
-                return;
-            }
+            Skip.IfNot(GD.GetPixelFormatSupport(format, TextureType.Texture2D, TextureUsage.Sampled));
 
             TextureDescription texDesc = TextureDescription.Texture2D(
                 16, 16,
@@ -346,7 +340,7 @@ namespace Veldrid.Tests
         [SkippableFact]
         public unsafe void Update_ThenMapRead_1D()
         {
-            if (!GD.Features.Texture1D) { return; }
+            Skip.IfNot(GD.Features.Texture1D);
 
             Texture tex1D = RF.CreateTexture(
                 TextureDescription.Texture1D(100, 1, 1, PixelFormat.R16_UNorm, TextureUsage.Staging));
@@ -367,7 +361,7 @@ namespace Veldrid.Tests
         [SkippableFact]
         public unsafe void MapWrite_ThenMapRead_1D()
         {
-            if (!GD.Features.Texture1D) { return; }
+            Skip.IfNot(GD.Features.Texture1D);
 
             Texture tex1D = RF.CreateTexture(
                 TextureDescription.Texture1D(100, 1, 1, PixelFormat.R16_UNorm, TextureUsage.Staging));
@@ -390,7 +384,7 @@ namespace Veldrid.Tests
         [SkippableFact]
         public unsafe void Copy_1DTo2D()
         {
-            if (!GD.Features.Texture1D) { return; }
+            Skip.IfNot(GD.Features.Texture1D);
 
             Texture tex1D = RF.CreateTexture(
                 TextureDescription.Texture1D(100, 1, 1, PixelFormat.R16_UNorm, TextureUsage.Staging));
@@ -426,7 +420,7 @@ namespace Veldrid.Tests
         [SkippableFact]
         public void Update_MultipleMips_1D()
         {
-            if (!GD.Features.Texture1D) { return; }
+            Skip.IfNot(GD.Features.Texture1D);
 
             Texture tex1D = RF.CreateTexture(TextureDescription.Texture1D(
                 100, 5, 1, PixelFormat.R8_G8_B8_A8_UNorm, TextureUsage.Staging));
@@ -455,7 +449,7 @@ namespace Veldrid.Tests
         [SkippableFact]
         public void Copy_DifferentMip_1DTo2D()
         {
-            if (!GD.Features.Texture1D) { return; }
+            Skip.IfNot(GD.Features.Texture1D);
 
             Texture tex1D = RF.CreateTexture(
                 TextureDescription.Texture1D(200, 2, 1, PixelFormat.R16_UNorm, TextureUsage.Staging));
@@ -629,6 +623,7 @@ namespace Veldrid.Tests
         [SkippableFact]
         public unsafe void Update_NonMultipleOfFourWithCompressedTexture_2D()
         {
+            Skip.IfNot(GD.GetPixelFormatSupport(PixelFormat.BC1_Rgb_UNorm, TextureType.Texture2D, TextureUsage.Staging));
             Texture tex2D = RF.CreateTexture(TextureDescription.Texture2D(
                 2, 2, 1, 1, PixelFormat.BC1_Rgb_UNorm, TextureUsage.Staging));
 
@@ -767,10 +762,7 @@ namespace Veldrid.Tests
             uint dstX, uint dstY, uint dstZ,
             uint dstMipLevel, uint dstArrayLayer)
         {
-            if (!GD.GetPixelFormatSupport(format, srcType, TextureUsage.Staging))
-            {
-                return;
-            }
+            Skip.IfNot(GD.GetPixelFormatSupport(format, srcType, TextureUsage.Staging));
 
             Texture srcTex = RF.CreateTexture(new TextureDescription(
                 srcWidth, srcHeight, srcDepth, srcMipLevels, srcArrayLayers,
@@ -899,6 +891,7 @@ namespace Veldrid.Tests
         [SkippableFact]
         public void CopyTexture_SmallCompressed()
         {
+            Skip.IfNot(GD.GetPixelFormatSupport(PixelFormat.BC3_UNorm, TextureType.Texture2D, TextureUsage.Staging));
             Texture src = RF.CreateTexture(TextureDescription.Texture2D(16, 16, 4, 1, PixelFormat.BC3_UNorm, TextureUsage.Staging));
             Texture dst = RF.CreateTexture(TextureDescription.Texture2D(16, 16, 4, 1, PixelFormat.BC3_UNorm, TextureUsage.Sampled));
 
@@ -930,6 +923,7 @@ namespace Veldrid.Tests
         [InlineData(PixelFormat.BC7_UNorm_SRgb)]
         public void CreateSmallTexture(PixelFormat format)
         {
+            Skip.IfNot(GD.GetPixelFormatSupport(format, TextureType.Texture2D, TextureUsage.Sampled));
             Texture tex = RF.CreateTexture(TextureDescription.Texture2D(1, 1, 1, 1, format, TextureUsage.Sampled));
             Assert.Equal(1u, tex.Width);
             Assert.Equal(1u, tex.Height);

--- a/src/Veldrid.Tests/TextureTests.cs
+++ b/src/Veldrid.Tests/TextureTests.cs
@@ -8,7 +8,7 @@ namespace Veldrid.Tests
 {
     public abstract class TextureTestBase<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
     {
-        [Fact]
+        [SkippableFact]
         public void Map_Succeeds()
         {
             Texture texture = RF.CreateTexture(
@@ -18,7 +18,7 @@ namespace Veldrid.Tests
             GD.Unmap(texture, 0);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Map_Succeeds_R32_G32_B32_A32_UInt()
         {
             Texture texture = RF.CreateTexture(
@@ -28,7 +28,7 @@ namespace Veldrid.Tests
             GD.Unmap(texture, 0);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(false)]
         [InlineData(true)]
         public unsafe void Update_ThenMapRead_Succeeds_R32Float(bool useArrayOverload)
@@ -63,7 +63,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(false)]
         [InlineData(true)]
         public unsafe void Update_ThenMapRead_SingleMip_Succeeds_R16UNorm(bool useArrayOverload)
@@ -99,7 +99,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public unsafe void Update_ThenCopySingleMip_Succeeds_R16UNorm()
         {
             TextureDescription desc = TextureDescription.Texture2D(
@@ -135,7 +135,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(PixelFormat.BC1_Rgb_UNorm, 8, 0, 0, 64, 64)]
         [InlineData(PixelFormat.BC1_Rgb_UNorm, 8, 8, 4, 16, 16)]
         [InlineData(PixelFormat.BC1_Rgb_UNorm_SRgb, 8, 0, 0, 64, 64)]
@@ -214,7 +214,7 @@ namespace Veldrid.Tests
 
         // [InlineData(true)]
         [InlineData(false)]
-        [Theory]
+        [SkippableTheory]
         public unsafe void Copy_Compressed_Array(bool separateLayerCopies)
         {
             PixelFormat format = PixelFormat.BC3_UNorm;
@@ -285,7 +285,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public unsafe void Update_ThenMapRead_3D()
         {
             Texture tex3D = RF.CreateTexture(TextureDescription.Texture3D(
@@ -318,7 +318,7 @@ namespace Veldrid.Tests
             GD.Unmap(tex3D);
         }
 
-        [Fact]
+        [SkippableFact]
         public unsafe void MapWrite_ThenMapRead_3D()
         {
             Texture tex3D = RF.CreateTexture(TextureDescription.Texture3D(
@@ -343,7 +343,7 @@ namespace Veldrid.Tests
             GD.Unmap(tex3D);
         }
 
-        [Fact]
+        [SkippableFact]
         public unsafe void Update_ThenMapRead_1D()
         {
             if (!GD.Features.Texture1D) { return; }
@@ -364,7 +364,7 @@ namespace Veldrid.Tests
             GD.Unmap(tex1D);
         }
 
-        [Fact]
+        [SkippableFact]
         public unsafe void MapWrite_ThenMapRead_1D()
         {
             if (!GD.Features.Texture1D) { return; }
@@ -387,7 +387,7 @@ namespace Veldrid.Tests
             GD.Unmap(tex1D);
         }
 
-        [Fact]
+        [SkippableFact]
         public unsafe void Copy_1DTo2D()
         {
             if (!GD.Features.Texture1D) { return; }
@@ -423,7 +423,7 @@ namespace Veldrid.Tests
             GD.Unmap(tex2D);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Update_MultipleMips_1D()
         {
             if (!GD.Features.Texture1D) { return; }
@@ -452,7 +452,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public void Copy_DifferentMip_1DTo2D()
         {
             if (!GD.Features.Texture1D) { return; }
@@ -492,7 +492,7 @@ namespace Veldrid.Tests
         [InlineData(TextureUsage.Staging, TextureUsage.Sampled)]
         [InlineData(TextureUsage.Sampled, TextureUsage.Staging)]
         [InlineData(TextureUsage.Sampled, TextureUsage.Sampled)]
-        [Theory]
+        [SkippableTheory]
         public void Copy_WithOffsets_2D(TextureUsage srcUsage, TextureUsage dstUsage)
         {
             Texture src = RF.CreateTexture(TextureDescription.Texture2D(
@@ -532,7 +532,7 @@ namespace Veldrid.Tests
             GD.Unmap(readback);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Copy_ArrayToNonArray()
         {
             Texture src = RF.CreateTexture(TextureDescription.Texture2D(
@@ -567,7 +567,7 @@ namespace Veldrid.Tests
             GD.Unmap(dst);
         }
 
-        [Fact]
+        [SkippableFact]
         public void Map_ThenRead_MultipleArrayLayers()
         {
             Texture src = RF.CreateTexture(TextureDescription.Texture2D(
@@ -596,7 +596,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public unsafe void Update_WithOffset_2D()
         {
             Texture tex2D = RF.CreateTexture(TextureDescription.Texture2D(
@@ -626,7 +626,7 @@ namespace Veldrid.Tests
                 }
         }
 
-        [Fact]
+        [SkippableFact]
         public unsafe void Update_NonMultipleOfFourWithCompressedTexture_2D()
         {
             Texture tex2D = RF.CreateTexture(TextureDescription.Texture2D(
@@ -644,7 +644,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public unsafe void Map_NonZeroMip_3D()
         {
             Texture tex3D = RF.CreateTexture(TextureDescription.Texture3D(
@@ -669,7 +669,7 @@ namespace Veldrid.Tests
             GD.Unmap(tex3D, 2);
         }
 
-        [Fact]
+        [SkippableFact]
         public unsafe void Update_NonStaging_3D()
         {
             Texture tex3D = RF.CreateTexture(TextureDescription.Texture3D(
@@ -711,7 +711,7 @@ namespace Veldrid.Tests
             GD.Unmap(staging);
         }
 
-        [Fact]
+        [SkippableFact]
         public unsafe void Copy_NonSquareTexture()
         {
             Texture src = RF.CreateTexture(
@@ -753,7 +753,7 @@ namespace Veldrid.Tests
             GD.Unmap(dst);
         }
 
-        [Theory]
+        [SkippableTheory]
         [MemberData(nameof(FormatCoverageData))]
         public unsafe void FormatCoverage_CopyThenRead(
             PixelFormat format, int rBits, int gBits, int bBits, int aBits,
@@ -856,7 +856,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(TextureUsage.Sampled | TextureUsage.GenerateMipmaps)]
         [InlineData(TextureUsage.RenderTarget | TextureUsage.GenerateMipmaps)]
         [InlineData(TextureUsage.Storage | TextureUsage.GenerateMipmaps)]
@@ -896,7 +896,7 @@ namespace Veldrid.Tests
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public void CopyTexture_SmallCompressed()
         {
             Texture src = RF.CreateTexture(TextureDescription.Texture2D(16, 16, 4, 1, PixelFormat.BC3_UNorm, TextureUsage.Staging));
@@ -913,7 +913,7 @@ namespace Veldrid.Tests
             GD.WaitForIdle();
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(PixelFormat.BC1_Rgb_UNorm)]
         [InlineData(PixelFormat.BC1_Rgb_UNorm_SRgb)]
         [InlineData(PixelFormat.BC1_Rgba_UNorm)]

--- a/src/Veldrid.Tests/Veldrid.Tests.csproj
+++ b/src/Veldrid.Tests/Veldrid.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.console" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
     <ProjectReference Include="..\Veldrid.RenderDoc\Veldrid.RenderDoc.csproj" />
     <ProjectReference Include="..\Veldrid.SDL2\Veldrid.SDL2.csproj" />
     <ProjectReference Include="..\Veldrid.StartupUtilities\Veldrid.StartupUtilities.csproj" />
@@ -50,6 +51,38 @@
     <None Remove="Shaders\FullScreenWriteDepth.vert" />
     <None Remove="Shaders\VertexLayoutTestShader.frag" />
     <None Remove="Shaders\VertexLayoutTestShader.vert" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Shaders\BasicComputeTest.comp" />
+    <EmbeddedResource Include="Shaders\ColoredQuadRenderer.frag" />
+    <EmbeddedResource Include="Shaders\ColoredQuadRenderer.vert" />
+    <EmbeddedResource Include="Shaders\ComputeColoredQuadGenerator.comp" />
+    <EmbeddedResource Include="Shaders\ComputeTextureGenerator.comp" />
+    <EmbeddedResource Include="Shaders\F16VertexAttribs.frag" />
+    <EmbeddedResource Include="Shaders\F16VertexAttribs.vert" />
+    <EmbeddedResource Include="Shaders\FillBuffer.comp" />
+    <EmbeddedResource Include="Shaders\FillBuffer_SeparateLayout.comp" />
+    <EmbeddedResource Include="Shaders\FullScreenBlit.frag" />
+    <EmbeddedResource Include="Shaders\FullScreenBlit.vert" />
+    <EmbeddedResource Include="Shaders\FullScreenTriSampleTexture.frag" />
+    <EmbeddedResource Include="Shaders\FullScreenTriSampleTexture.vert" />
+    <EmbeddedResource Include="Shaders\FullScreenTriSampleTexture2D.frag" />
+    <EmbeddedResource Include="Shaders\FullScreenTriSampleTexture2D.vert" />
+    <EmbeddedResource Include="Shaders\FullScreenTriSampleTextureArray.frag" />
+    <EmbeddedResource Include="Shaders\FullScreenTriSampleTextureArray.vert" />
+    <EmbeddedResource Include="Shaders\FullScreenWriteDepth.frag" />
+    <EmbeddedResource Include="Shaders\FullScreenWriteDepth.vert" />
+    <EmbeddedResource Include="Shaders\TexturedPoints.frag" />
+    <EmbeddedResource Include="Shaders\TexturedPoints.vert" />
+    <EmbeddedResource Include="Shaders\U16NormVertexAttribs.frag" />
+    <EmbeddedResource Include="Shaders\U16NormVertexAttribs.vert" />
+    <EmbeddedResource Include="Shaders\U16VertexAttribs.frag" />
+    <EmbeddedResource Include="Shaders\U16VertexAttribs.vert" />
+    <EmbeddedResource Include="Shaders\UIntVertexAttribs.frag" />
+    <EmbeddedResource Include="Shaders\UIntVertexAttribs.vert" />
+    <EmbeddedResource Include="Shaders\VertexLayoutTestShader.frag" />
+    <EmbeddedResource Include="Shaders\VertexLayoutTestShader.vert" />
   </ItemGroup>
 
 </Project>

--- a/src/Veldrid.Tests/VertexLayoutTests.cs
+++ b/src/Veldrid.Tests/VertexLayoutTests.cs
@@ -6,7 +6,7 @@ namespace Veldrid.Tests
 
     public abstract class VertexLayoutTests<T> : GraphicsDeviceTestBase<T> where T : GraphicsDeviceCreator
     {
-        [Theory]
+        [SkippableTheory]
         [InlineData(0, 0, 0, 0, -1, true)]
         [InlineData(0, 12, 28, 36, -1, true)]
         [InlineData(0, 16, 32, 48, -1, true)]

--- a/src/Veldrid.sln
+++ b/src/Veldrid.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.31911.260
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Veldrid", "Veldrid\Veldrid.csproj", "{60D56E4A-FA7A-4664-BEF0-0A29F41518BF}"
 EndProject
@@ -29,10 +29,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Veldrid.VirtualReality.Samp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Veldrid.RenderDoc", "Veldrid.RenderDoc\Veldrid.RenderDoc.csproj", "{AFAEF056-CAD3-4C32-AEC3-AAC35A251295}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Veldrid.Tests.Android", "Veldrid.Tests.Android\Veldrid.Tests.Android.csproj", "{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}"
+EndProject
 Global
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM = Debug|ARM
@@ -252,12 +251,39 @@ Global
 		{AFAEF056-CAD3-4C32-AEC3-AAC35A251295}.Release|x64.Build.0 = Release|Any CPU
 		{AFAEF056-CAD3-4C32-AEC3-AAC35A251295}.Release|x86.ActiveCfg = Release|Any CPU
 		{AFAEF056-CAD3-4C32-AEC3-AAC35A251295}.Release|x86.Build.0 = Release|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Debug|ARM.Build.0 = Debug|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Debug|ARM.Deploy.0 = Debug|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Debug|x64.Build.0 = Debug|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Debug|x64.Deploy.0 = Debug|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Debug|x86.Build.0 = Debug|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Debug|x86.Deploy.0 = Debug|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Release|ARM.Build.0 = Release|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Release|ARM.Deploy.0 = Release|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Release|x64.ActiveCfg = Release|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Release|x64.Build.0 = Release|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Release|x64.Deploy.0 = Release|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Release|x86.ActiveCfg = Release|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Release|x86.Build.0 = Release|Any CPU
+		{B2EE8C28-75E3-4039-8A7C-51CE10BA021D}.Release|x86.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {212564A4-FE40-45A2-8AE6-A466B277810C}
+	EndGlobalSection
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
 	EndGlobalSection
 	GlobalSection(Performance) = preSolution
 		HasPerformanceSessions = true

--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -193,7 +193,8 @@ namespace Veldrid.D3D11
                 subsetTextureView: true,
                 commandListDebugMarkers: _device.FeatureLevel >= Vortice.Direct3D.FeatureLevel.Level_11_1,
                 bufferRangeBinding: _device.FeatureLevel >= Vortice.Direct3D.FeatureLevel.Level_11_1,
-                shaderFloat64: _device.CheckFeatureSupport<FeatureDataDoubles>(Vortice.Direct3D11.Feature.Doubles).DoublePrecisionFloatShaderOps);
+                shaderFloat64: _device.CheckFeatureSupport<FeatureDataDoubles>(Vortice.Direct3D11.Feature.Doubles).DoublePrecisionFloatShaderOps,
+                cubeMapArrayTextures: true);
 
             _d3d11ResourceFactory = new D3D11ResourceFactory(this);
             _d3d11Info = new BackendInfoD3D11(this);

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -850,7 +850,7 @@ namespace Veldrid
             WaitForIdle();
             PointSampler.Dispose();
             LinearSampler.Dispose();
-            Aniso4xSampler.Dispose();
+            _aniso4xSampler?.Dispose();
             PlatformDispose();
         }
 

--- a/src/Veldrid/GraphicsDeviceFeatures.cs
+++ b/src/Veldrid/GraphicsDeviceFeatures.cs
@@ -95,6 +95,10 @@
         /// Indicates whether 64-bit floating point integers can be used in shaders.
         /// </summary>
         public bool ShaderFloat64 { get; }
+        /// <summary>
+        /// Indicates whether cube map array textures are supported.
+        /// </summary>
+        public bool CubeMapArrayTextures { get; }
 
         internal GraphicsDeviceFeatures(
             bool computeShader,
@@ -115,7 +119,8 @@
             bool subsetTextureView,
             bool commandListDebugMarkers,
             bool bufferRangeBinding,
-            bool shaderFloat64)
+            bool shaderFloat64,
+            bool cubeMapArrayTextures)
         {
             ComputeShader = computeShader;
             GeometryShader = geometryShader;
@@ -136,6 +141,7 @@
             CommandListDebugMarkers = commandListDebugMarkers;
             BufferRangeBinding = bufferRangeBinding;
             ShaderFloat64 = shaderFloat64;
+            CubeMapArrayTextures = cubeMapArrayTextures;
         }
     }
 }

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -79,7 +79,8 @@ namespace Veldrid.MTL
                 subsetTextureView: true,
                 commandListDebugMarkers: true,
                 bufferRangeBinding: true,
-                shaderFloat64: false);
+                shaderFloat64: false,
+                cubeMapArrayTextures: true);
             ResourceBindingModel = options.ResourceBindingModel;
 
             _libSystem = new NativeLibrary("libSystem.dylib");

--- a/src/Veldrid/OpenGL/EGL/EGLNative.cs
+++ b/src/Veldrid/OpenGL/EGL/EGLNative.cs
@@ -51,6 +51,10 @@ namespace Veldrid.OpenGL.EGL
             IntPtr native_window,
             int* attrib_list);
         [DllImport(LibName)]
+        public static extern int eglDestroySurface(
+            IntPtr display,
+            IntPtr surface);
+        [DllImport(LibName)]
         public static extern IntPtr eglCreateContext(IntPtr display,
             IntPtr config,
             IntPtr share_context,

--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -1654,7 +1654,17 @@ namespace Veldrid.OpenGL
                         glBindFramebuffer(FramebufferTarget.ReadFramebuffer, readFB);
                         CheckLastError();
 
-                        if (srcGLTexture.ArrayLayers > 1 || srcGLTexture.Type == TextureType.Texture3D
+                        if (srcGLTexture.ArrayLayers == 1 && (srcGLTexture.Usage & TextureUsage.Cubemap) != 0)
+                        {
+                            glFramebufferTexture2D(
+                                FramebufferTarget.ReadFramebuffer,
+                                GLFramebufferAttachment.ColorAttachment0,
+                                GetCubeTarget(curLayer),
+                                srcGLTexture.Texture,
+                                (int)srcMipLevel);
+                            CheckLastError();
+                        }
+                        else if (srcGLTexture.ArrayLayers > 1 || srcGLTexture.Type == TextureType.Texture3D
                             || (srcGLTexture.Usage & TextureUsage.Cubemap) != 0)
                         {
                             glFramebufferTextureLayer(

--- a/src/Veldrid/OpenGL/OpenGLExtensions.cs
+++ b/src/Veldrid/OpenGL/OpenGLExtensions.cs
@@ -54,6 +54,8 @@ namespace Veldrid.OpenGL
             StorageBuffers = GLVersion(4, 3) || IsExtensionSupported("GL_ARB_shader_storage_buffer_object")
                 || GLESVersion(3, 1);
 
+            CubeMapArrayTexture = GLVersion(1, 3) || GLESVersion(3, 2);
+
             ARB_ClipControl = GLVersion(4, 5) || IsExtensionSupported("GL_ARB_clip_control");
             EXT_sRGBWriteControl = _backend == GraphicsBackend.OpenGLES && IsExtensionSupported("GL_EXT_sRGB_write_control");
             EXT_DebugMarker = _backend == GraphicsBackend.OpenGLES && IsExtensionSupported("GL_EXT_debug_marker");
@@ -91,6 +93,7 @@ namespace Veldrid.OpenGL
         public readonly bool MultiDrawIndirect;
         public readonly bool StorageBuffers;
         public readonly bool AnisotropicFilter;
+        public readonly bool CubeMapArrayTexture;
 
         /// <summary>
         /// Returns a value indicating whether the given extension is supported.

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -720,10 +720,16 @@ namespace Veldrid.OpenGL
 
             Action<IntPtr> destroyContext = ctx =>
             {
+                clearContext();
+                if(eglDestroySurface(display, eglWindowSurface) == 0)
+                {
+                    throw new VeldridException($"Failed to destroy EGLSurface {eglWindowSurface}: {eglGetError()}");
+                }
                 if (eglDestroyContext(display, ctx) == 0)
                 {
                     throw new VeldridException($"Failed to destroy EGLContext {ctx}: {eglGetError()}");
                 }
+                var err = eglGetError();
             };
 
             OpenGLPlatformInfo platformInfo = new OpenGLPlatformInfo(

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -193,7 +193,8 @@ namespace Veldrid.OpenGL
                 subsetTextureView: _extensions.ARB_TextureView,
                 commandListDebugMarkers: _extensions.KHR_Debug || _extensions.EXT_DebugMarker,
                 bufferRangeBinding: _extensions.ARB_uniform_buffer_object,
-                shaderFloat64: _extensions.ARB_GpuShaderFp64);
+                shaderFloat64: _extensions.ARB_GpuShaderFp64,
+                cubeMapArrayTextures: _extensions.CubeMapArrayTexture);
 
             int uboAlignment;
             glGetIntegerv(GetPName.UniformBufferOffsetAlignment, &uboAlignment);

--- a/src/Veldrid/OpenGL/OpenGLPipeline.cs
+++ b/src/Veldrid/OpenGL/OpenGLPipeline.cs
@@ -439,8 +439,11 @@ namespace Veldrid.OpenGL
             if (!_disposed)
             {
                 _disposed = true;
-                glDeleteProgram(_program);
-                CheckLastError();
+                if (Created)
+                {
+                    glDeleteProgram(_program);
+                    CheckLastError();
+                }
             }
         }
     }

--- a/src/Veldrid/Vk/VkGraphicsDevice.cs
+++ b/src/Veldrid/Vk/VkGraphicsDevice.cs
@@ -161,7 +161,8 @@ namespace Veldrid.Vk
                 subsetTextureView: true,
                 commandListDebugMarkers: _debugMarkerEnabled,
                 bufferRangeBinding: true,
-                shaderFloat64: _physicalDeviceFeatures.shaderFloat64);
+                shaderFloat64: _physicalDeviceFeatures.shaderFloat64,
+                cubeMapArrayTextures: true);
 
             ResourceFactory = new VkResourceFactory(this);
 


### PR DESCRIPTION
Runs on the emulator with veldrid-spirv updated with binaries from https://github.com/mellinoe/veldrid-spirv/pull/19.

![image](https://user-images.githubusercontent.com/579018/149578611-b0f1de56-24fb-416c-89b0-35f8a642e380.png)

![image](https://user-images.githubusercontent.com/579018/149579728-570aef67-8a8b-466e-a453-075ebf2651cf.png)

Emulator fails the following tests:

- OpenGLESRenderTests.WriteFragmentDepth (CopyRoundabout InvalidEnum)
- OpenGLESTextureTests.FormatCoverage_CopyThenRead
  - R16_G16_B16_A16_SInt
  - R16_G16_B16_A16_SNorm
  - R16_G16_B16_A16_UInt
  - R16_G16_B16_A16_UNorm
  - R16_G16_SInt
  - R16_G16_SNorm
  - R16_G16_UInt
  - R16_G16_UNorm
  - R16_SInt
  - R16_SNorm
  - R16_UInt
  - R16_UNorm
- OpenGLESTextureTests.Update_ThenCopySingleMip_Succeeds_R16UNorm
- OpenGLESTextureTests.Update_ThenMapRead_SingleMip_Succeeds_R16UNorm

Example FormatCoverage failure
![image](https://user-images.githubusercontent.com/579018/149580889-380c5f62-2d67-4500-9e70-38f1b784a7fc.png)
```
[emuglGLESv2_enc] device/generic/goldfish-opengl/system/GLESv2_enc/GL2Encoder.cpp:s_glReadPixels:4831 GL error 0x500 condition [!GLESv2Validation::readPixelsType(type)]
```
https://android.googlesource.com/device/generic/goldfish-opengl/+/emu-master-qemu-release/system/GLESv2_enc/GL2Encoder.cpp#4076
https://android.googlesource.com/device/generic/goldfish-opengl/+/emu-master-qemu-release/system/GLESv2_enc/GLESv2Validation.cpp#244
It seems like GLES glReadPixels is very strict about accepted types https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glReadPixels.xhtml.
```
 Only two format/type parameter pairs are accepted. For normalized fixed point rendering surfaces, GL_RGBA/GL_UNSIGNED_BYTE is accepted. For signed integer rendering surfaces, GL_RGBA_INTEGER/GL_INT is accepted. For unsigned integer rendering surfaces, GL_RGBA_INTEGER/GL_UNSIGNED_INT is accepted. The other acceptable pair can be discovered by querying GL_IMPLEMENTATION_COLOR_READ_FORMAT and GL_IMPLEMENTATION_COLOR_READ_TYPE. The implementation chosen format may also vary depending on the format of the currently bound rendering surface. 
```
Other engines appear to read GL_RGBA, GL_UNSIGNED_BYTE and then do pixel conversions https://github.com/godotengine/godot/blob/095c72b03ecedde87bf9e4aac0f8576d829dd9ee/drivers/gles3/rasterizer_storage_gles3.cpp#L1033 https://github.com/OGRECave/ogre/blob/65f90ac18cf3b9566b3a8928f1006588899a73fd/RenderSystems/GLES2/src/OgreGLES2HardwarePixelBuffer.cpp#L373.

Also runs on device (Galaxy Note9)
![Screenshot_20220114-122316_VeldridTestsAndroid](https://user-images.githubusercontent.com/579018/149580448-a526cbba-1b8c-44ad-8a09-74e981459180.jpg)
![Screenshot_20220114-122330_VeldridTestsAndroid](https://user-images.githubusercontent.com/579018/149580507-39b5a92a-fc91-47f7-8cb7-f5ccf97bf18d.jpg)

