### PR TITLE
update Nerdbank version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <NerdbankGitVersioningVersion>3.3.37</NerdbankGitVersioningVersion>
+    <NerdbankGitVersioningVersion>3.4.255</NerdbankGitVersioningVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
this fixes the issue where the Github CI pipeline crashes intermittently.