### PR TITLE
Update and improvements.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore src
     - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 5.0.x
     - name: Restore dependencies
       run: dotnet restore src
     - name: Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,7 +47,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="$(NerdbankGitVersioningVersion)" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,8 +10,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VeldridSpirvVersion>1.0.9</VeldridSpirvVersion>
-    <NativeLibraryLoaderVersion>1.0.10</NativeLibraryLoaderVersion>
+    <VeldridSpirvVersion>1.0.14</VeldridSpirvVersion>
+    <NativeLibraryLoaderVersion>1.0.12</NativeLibraryLoaderVersion>
+    <VorticeWindowsVersion>2.1.0</VorticeWindowsVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -28,7 +29,7 @@
     <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
   </PropertyGroup>
 
-   <PropertyGroup>
+  <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -38,10 +39,14 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <NerdbankGitVersioningVersion>3.3.37</NerdbankGitVersioningVersion>
+    <NerdbankGitVersioningVersion>3.4.255</NerdbankGitVersioningVersion>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="$(NerdbankGitVersioningVersion)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(NerdbankGitVersioningVersion)" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/NeoDemo/NeoDemo.csproj
+++ b/src/NeoDemo/NeoDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Veldrid.NeoDemo</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>

--- a/src/Veldrid.MetalBindings/Veldrid.MetalBindings.csproj
+++ b/src/Veldrid.MetalBindings/Veldrid.MetalBindings.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Veldrid.Tests/ComputeTests.cs
+++ b/src/Veldrid.Tests/ComputeTests.cs
@@ -198,8 +198,8 @@ void main()
             uint width = 1024;
             uint height = 1024;
             DeviceBuffer paramsBuffer = RF.CreateBuffer(new BufferDescription((uint)Unsafe.SizeOf<BasicComputeTestParams>(), BufferUsage.UniformBuffer));
-            DeviceBuffer sourceBuffer = RF.CreateBuffer(new BufferDescription(width * height * 4, BufferUsage.StructuredBufferReadWrite, 4));
-            DeviceBuffer destinationBuffer = RF.CreateBuffer(new BufferDescription(width * height * 4, BufferUsage.StructuredBufferReadWrite, 4));
+            DeviceBuffer sourceBuffer = RF.CreateBuffer(new BufferDescription(width * height * 4, BufferUsage.StructuredBufferReadWrite, 4, true));
+            DeviceBuffer destinationBuffer = RF.CreateBuffer(new BufferDescription(width * height * 4, BufferUsage.StructuredBufferReadWrite, 4, true));
 
             GD.UpdateBuffer(paramsBuffer, 0, new BasicComputeTestParams { Width = width, Height = height });
 
@@ -259,9 +259,9 @@ void main()
             uint totalDstAlignment = GD.StructuredBufferMinOffsetAlignment * (dstSetMultiple + dstBindingMultiple);
 
             DeviceBuffer copySrc = RF.CreateBuffer(
-                new BufferDescription(totalSrcAlignment + dataSize, BufferUsage.StructuredBufferReadOnly, sizeof(uint)));
+                new BufferDescription(totalSrcAlignment + dataSize, BufferUsage.StructuredBufferReadOnly, sizeof(uint), true));
             DeviceBuffer copyDst = RF.CreateBuffer(
-                new BufferDescription(totalDstAlignment + dataSize, BufferUsage.StructuredBufferReadWrite, sizeof(uint)));
+                new BufferDescription(totalDstAlignment + dataSize, BufferUsage.StructuredBufferReadWrite, sizeof(uint), true));
 
             ResourceLayout[] layouts;
             ResourceSet[] sets;

--- a/src/Veldrid/D3D11/D3D11Buffer.cs
+++ b/src/Veldrid/D3D11/D3D11Buffer.cs
@@ -136,14 +136,12 @@ namespace Veldrid.D3D11
         {
             if (_rawBuffer)
             {
-                ShaderResourceViewDescription srvDesc = new ShaderResourceViewDescription
-                {
-                    ViewDimension = ShaderResourceViewDimension.BufferExtended,
-                    Format = Format.R32_Typeless
-                };
-                srvDesc.BufferEx.NumElements = (int)size / 4;
-                srvDesc.BufferEx.Flags = BufferExtendedShaderResourceViewFlags.Raw;
-                srvDesc.BufferEx.FirstElement = (int)offset / 4;
+                ShaderResourceViewDescription srvDesc = new ShaderResourceViewDescription(_buffer,
+                    Format.R32_Typeless,
+                    (int)offset / 4,
+                    (int)size / 4,
+                    BufferExtendedShaderResourceViewFlags.Raw);
+
                 return _device.CreateShaderResourceView(_buffer, srvDesc);
             }
             else
@@ -162,29 +160,21 @@ namespace Veldrid.D3D11
         {
             if (_rawBuffer)
             {
-                UnorderedAccessViewDescription uavDesc = new UnorderedAccessViewDescription
-                {
-                    ViewDimension = UnorderedAccessViewDimension.Buffer
-                };
-
-                uavDesc.Buffer.NumElements = (int)size / 4;
-                uavDesc.Buffer.Flags = BufferUnorderedAccessViewFlags.Raw;
-                uavDesc.Format = Format.R32_Typeless;
-                uavDesc.Buffer.FirstElement = (int)offset / 4;
+                UnorderedAccessViewDescription uavDesc = new UnorderedAccessViewDescription(_buffer,
+                    Format.R32_Typeless,
+                    (int)offset / 4,
+                    (int)size / 4,
+                    BufferUnorderedAccessViewFlags.Raw);
 
                 return _device.CreateUnorderedAccessView(_buffer, uavDesc);
-
             }
             else
             {
-                UnorderedAccessViewDescription uavDesc = new UnorderedAccessViewDescription
-                {
-                    ViewDimension = UnorderedAccessViewDimension.Buffer
-                };
-
-                uavDesc.Buffer.NumElements = (int)(size / _structureByteStride);
-                uavDesc.Format = Format.Unknown;
-                uavDesc.Buffer.FirstElement = (int)(offset / _structureByteStride);
+                UnorderedAccessViewDescription uavDesc = new UnorderedAccessViewDescription(_buffer,
+                    Format.Unknown,
+                    (int)(offset / _structureByteStride),
+                    (int)(size / _structureByteStride)
+                    );
 
                 return _device.CreateUnorderedAccessView(_buffer, uavDesc);
             }

--- a/src/Veldrid/D3D11/D3D11Buffer.cs
+++ b/src/Veldrid/D3D11/D3D11Buffer.cs
@@ -23,7 +23,7 @@ namespace Veldrid.D3D11
 
         public override BufferUsage Usage { get; }
 
-        public override bool IsDisposed => _buffer.IsDisposed;
+        public override bool IsDisposed => _buffer.NativePointer == IntPtr.Zero;
 
         public ID3D11Buffer Buffer => _buffer;
 
@@ -38,7 +38,7 @@ namespace Veldrid.D3D11
             Vortice.Direct3D11.BufferDescription bd = new Vortice.Direct3D11.BufferDescription(
                 (int)sizeInBytes,
                 D3D11Formats.VdToD3D11BindFlags(usage),
-                Vortice.Direct3D11.Usage.Default);
+                ResourceUsage.Default);
             if ((usage & BufferUsage.StructuredBufferReadOnly) == BufferUsage.StructuredBufferReadOnly
                 || (usage & BufferUsage.StructuredBufferReadWrite) == BufferUsage.StructuredBufferReadWrite)
             {
@@ -59,12 +59,12 @@ namespace Veldrid.D3D11
 
             if ((usage & BufferUsage.Dynamic) == BufferUsage.Dynamic)
             {
-                bd.Usage = Vortice.Direct3D11.Usage.Dynamic;
+                bd.Usage = ResourceUsage.Dynamic;
                 bd.CpuAccessFlags = CpuAccessFlags.Write;
             }
             else if ((usage & BufferUsage.Staging) == BufferUsage.Staging)
             {
-                bd.Usage = Vortice.Direct3D11.Usage.Staging;
+                bd.Usage = ResourceUsage.Staging;
                 bd.CpuAccessFlags = CpuAccessFlags.Read | CpuAccessFlags.Write;
             }
 

--- a/src/Veldrid/D3D11/D3D11Formats.cs
+++ b/src/Veldrid/D3D11/D3D11Formats.cs
@@ -399,15 +399,15 @@ namespace Veldrid.D3D11
                 case StencilOperation.Replace:
                     return Vortice.Direct3D11.StencilOperation.Replace;
                 case StencilOperation.IncrementAndClamp:
-                    return Vortice.Direct3D11.StencilOperation.IncrSat;
+                    return Vortice.Direct3D11.StencilOperation.IncrementSaturate;
                 case StencilOperation.DecrementAndClamp:
-                    return Vortice.Direct3D11.StencilOperation.DecrSat;
+                    return Vortice.Direct3D11.StencilOperation.DecrementSaturate;
                 case StencilOperation.Invert:
-                    return Vortice.Direct3D11.StencilOperation.InverseErt;
+                    return Vortice.Direct3D11.StencilOperation.Invert;
                 case StencilOperation.IncrementAndWrap:
-                    return Vortice.Direct3D11.StencilOperation.Incr;
+                    return Vortice.Direct3D11.StencilOperation.Increment;
                 case StencilOperation.DecrementAndWrap:
-                    return Vortice.Direct3D11.StencilOperation.Decr;
+                    return Vortice.Direct3D11.StencilOperation.Decrement;
                 default:
                     throw Illegal.Value<StencilOperation>();
             }

--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -10,6 +10,7 @@ using Vortice.Mathematics;
 using Vortice.Direct3D11.Debug;
 using VorticeDXGI = Vortice.DXGI.DXGI;
 using VorticeD3D11 = Vortice.Direct3D11.D3D11;
+using Vortice.DXGI.Debug;
 
 namespace Veldrid.D3D11
 {
@@ -679,7 +680,7 @@ namespace Veldrid.D3D11
                 // Report live objects using DXGI if available (DXGIGetDebugInterface1 will fail on pre Windows 8 OS).
                 if (VorticeDXGI.DXGIGetDebugInterface1(out IDXGIDebug1 dxgiDebug).Success)
                 {
-                    dxgiDebug.ReportLiveObjects(VorticeDXGI.All, ReportLiveObjectFlags.Summary | ReportLiveObjectFlags.IgnoreInternal);
+                    dxgiDebug.ReportLiveObjects(VorticeDXGI.DebugAll, ReportLiveObjectFlags.Summary | ReportLiveObjectFlags.IgnoreInternal);
                     dxgiDebug.Dispose();
                 }
             }

--- a/src/Veldrid/D3D11/D3D11Sampler.cs
+++ b/src/Veldrid/D3D11/D3D11Sampler.cs
@@ -1,4 +1,5 @@
-﻿using Vortice.Direct3D11;
+﻿using System;
+using Vortice.Direct3D11;
 using Vortice.Mathematics;
 
 namespace Veldrid.D3D11
@@ -54,7 +55,7 @@ namespace Veldrid.D3D11
             }
         }
 
-        public override bool IsDisposed => DeviceSampler.IsDisposed;
+        public override bool IsDisposed => DeviceSampler.NativePointer == IntPtr.Zero;
 
         public override void Dispose()
         {

--- a/src/Veldrid/D3D11/D3D11Shader.cs
+++ b/src/Veldrid/D3D11/D3D11Shader.cs
@@ -104,7 +104,7 @@ namespace Veldrid.D3D11
             }
         }
 
-        public override bool IsDisposed => DeviceShader.IsDisposed;
+        public override bool IsDisposed => DeviceShader.NativePointer == IntPtr.Zero;
 
         public override void Dispose()
         {

--- a/src/Veldrid/D3D11/D3D11Swapchain.cs
+++ b/src/Veldrid/D3D11/D3D11Swapchain.cs
@@ -83,13 +83,13 @@ namespace Veldrid.D3D11
                 SwapChainDescription dxgiSCDesc = new SwapChainDescription
                 {
                     BufferCount = 2,
-                    IsWindowed = true,
+                    Windowed = true,
                     BufferDescription = new ModeDescription(
                         (int)description.Width, (int)description.Height, _colorFormat),
                     OutputWindow = win32Source.Hwnd,
                     SampleDescription = new SampleDescription(1, 0),
                     SwapEffect = SwapEffect.Discard,
-                    Usage = Vortice.DXGI.Usage.RenderTargetOutput
+                    BufferUsage = Usage.RenderTargetOutput
                 };
 
                 using (IDXGIFactory dxgiFactory = _gd.Adapter.GetParent<IDXGIFactory>())
@@ -112,7 +112,7 @@ namespace Veldrid.D3D11
                     Width = (int)(description.Width * _pixelScale),
                     SampleDescription = new SampleDescription(1, 0),
                     SwapEffect = SwapEffect.FlipSequential,
-                    Usage = Vortice.DXGI.Usage.RenderTargetOutput,
+                    BufferUsage = Usage.RenderTargetOutput,
                 };
 
                 // Get the Vortice.DXGI factory automatically created when initializing the Direct3D device.

--- a/src/Veldrid/D3D11/D3D11Texture.cs
+++ b/src/Veldrid/D3D11/D3D11Texture.cs
@@ -18,7 +18,7 @@ namespace Veldrid.D3D11
         public override TextureUsage Usage { get; }
         public override TextureType Type { get; }
         public override TextureSampleCount SampleCount { get; }
-        public override bool IsDisposed => DeviceTexture.IsDisposed;
+        public override bool IsDisposed => DeviceTexture.NativePointer == IntPtr.Zero;
 
         public ID3D11Resource DeviceTexture { get; }
         public Vortice.DXGI.Format DxgiFormat { get; }
@@ -43,7 +43,7 @@ namespace Veldrid.D3D11
             TypelessDxgiFormat = D3D11Formats.GetTypelessFormat(DxgiFormat);
 
             CpuAccessFlags cpuFlags = CpuAccessFlags.None;
-            Usage resourceUsage = Vortice.Direct3D11.Usage.Default;
+            ResourceUsage resourceUsage = ResourceUsage.Default;
             BindFlags bindFlags = BindFlags.None;
             ResourceOptionFlags optionFlags = ResourceOptionFlags.None;
 
@@ -66,7 +66,7 @@ namespace Veldrid.D3D11
             if ((description.Usage & TextureUsage.Staging) == TextureUsage.Staging)
             {
                 cpuFlags = CpuAccessFlags.Read | CpuAccessFlags.Write;
-                resourceUsage = Vortice.Direct3D11.Usage.Staging;
+                resourceUsage = ResourceUsage.Staging;
             }
 
             if ((description.Usage & TextureUsage.GenerateMipmaps) != 0)

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -13,16 +13,19 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="NativeLibraryLoader" Version="1.0.12" />
 
     <PackageReference Include="Vk" Version="1.0.25" Condition="'$(ExcludeVulkan)' != 'true'" />
 
-    <PackageReference Include="Vortice.D3DCompiler" Version="1.9.56" Condition="'$(ExcludeD3D11)' != 'true'" />
-    <PackageReference Include="Vortice.Direct3D11" Version="1.9.56" Condition="'$(ExcludeD3D11)' != 'true'" />
+    <PackageReference Include="Vortice.D3DCompiler" Version="$(VorticeWindowsVersion)" Condition="'$(ExcludeD3D11)' != 'true'" />
+    <PackageReference Include="Vortice.Direct3D11" Version="$(VorticeWindowsVersion)" Condition="'$(ExcludeD3D11)' != 'true'" />
 
     <ProjectReference Include="..\Veldrid.MetalBindings\Veldrid.MetalBindings.csproj" Condition="'$(ExcludeMetal)' != 'true'" />
 


### PR DESCRIPTION
- Update Vortice.Windows to latest 2.1.0 stable release.
- Install .NET SDK 6.0 in CI build for future .NET 6.0 update.
- Cleanup dependencies.