### PR TITLE
Add "color write" masking support in blend attachments

### DIFF
--- a/src/NeoDemo/Objects/FullScreenQuad.cs
+++ b/src/NeoDemo/Objects/FullScreenQuad.cs
@@ -10,7 +10,8 @@ namespace Veldrid.NeoDemo.Objects
         private Pipeline _pipeline;
         private DeviceBuffer _ib;
         private DeviceBuffer _vb;
-        public bool UseTintedTexture { get; set; }
+
+        public bool UseMultipleRenderTargets { get; set; }
 
         public override void CreateDeviceObjects(GraphicsDevice gd, CommandList cl, SceneContext sc)
         {
@@ -66,7 +67,7 @@ namespace Veldrid.NeoDemo.Objects
         public override void Render(GraphicsDevice gd, CommandList cl, SceneContext sc, RenderPasses renderPass)
         {
             cl.SetPipeline(_pipeline);
-            cl.SetGraphicsResourceSet(0, UseTintedTexture ? sc.DuplicatorTargetSet1 : sc.DuplicatorTargetSet0);
+            cl.SetGraphicsResourceSet(0, UseMultipleRenderTargets ? sc.DuplicatorTargetSet1 : sc.DuplicatorTargetSet0);
             cl.SetVertexBuffer(0, _vb);
             cl.SetIndexBuffer(_ib, IndexFormat.UInt16);
             cl.DrawIndexed(6, 1, 0, 0, 0);

--- a/src/NeoDemo/Objects/ScreenDuplicator.cs
+++ b/src/NeoDemo/Objects/ScreenDuplicator.cs
@@ -21,11 +21,13 @@ namespace Veldrid.NeoDemo.Objects
 
             (Shader vs, Shader fs) = StaticResourceCache.GetShaders(gd, gd.ResourceFactory, "ScreenDuplicator");
 
+            var blend = BlendAttachmentDescription.OverrideBlend;
+            blend.ColorWriteMask = sc.MainSceneMask;
+
             GraphicsPipelineDescription pd = new GraphicsPipelineDescription(
                 new BlendStateDescription(
                     RgbaFloat.Black,
-                    BlendAttachmentDescription.OverrideBlend,
-                    BlendAttachmentDescription.OverrideBlend),
+                    blend, blend),
                 gd.IsDepthRangeZeroToOne ? DepthStencilStateDescription.DepthOnlyGreaterEqual : DepthStencilStateDescription.DepthOnlyLessEqual,
                 RasterizerStateDescription.Default,
                 PrimitiveTopology.TriangleList,

--- a/src/NeoDemo/Scene.cs
+++ b/src/NeoDemo/Scene.cs
@@ -194,6 +194,7 @@ namespace Veldrid.NeoDemo
             cl.SetViewport(0, new Viewport(0, 0, fbWidth, fbHeight, 0, 1));
             cl.SetFullViewports();
             cl.SetFullScissorRects();
+            cl.ClearColorTarget(0, RgbaFloat.Black);
             cl.ClearDepthStencil(depthClear);
             sc.UpdateCameraBuffers(cl); // Re-set because reflection step changed it.
             cameraFrustum = new BoundingFrustum(_camera.ViewMatrix * _camera.ProjectionMatrix);

--- a/src/NeoDemo/SceneContext.cs
+++ b/src/NeoDemo/SceneContext.cs
@@ -54,6 +54,7 @@ namespace Veldrid.NeoDemo
         public Camera Camera { get; set; }
         public DirectionalLight DirectionalLight { get; } = new DirectionalLight();
         public TextureSampleCount MainSceneSampleCount { get; internal set; }
+        public ColorWriteMask MainSceneMask { get; internal set; } = ColorWriteMask.All;
         public DeviceBuffer MirrorClipPlaneBuffer { get; private set; }
         public DeviceBuffer NoClipPlaneBuffer { get; private set; }
 

--- a/src/Veldrid.MetalBindings/MTLColorWriteMask.cs
+++ b/src/Veldrid.MetalBindings/MTLColorWriteMask.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Veldrid.MetalBindings
+{
+    [Flags]
+    public enum MTLColorWriteMask
+    {
+        None = 0,
+        Red = 1 << 3,
+        Green = 1 << 2,
+        Blue = 1 << 1,
+        Alpha = 1 << 0,
+        All = Red | Green | Blue | Alpha,
+    }
+}

--- a/src/Veldrid.MetalBindings/MTLRenderPipelineColorAttachmentDescriptor.cs
+++ b/src/Veldrid.MetalBindings/MTLRenderPipelineColorAttachmentDescriptor.cs
@@ -17,6 +17,12 @@ namespace Veldrid.MetalBindings
             set => objc_msgSend(NativePtr, Selectors.setPixelFormat, (uint)value);
         }
 
+        public MTLColorWriteMask writeMask
+        {
+            get => (MTLColorWriteMask)uint_objc_msgSend(NativePtr, sel_writeMask);
+            set => objc_msgSend(NativePtr, sel_setWriteMask, (uint)value);
+        }
+
         public Bool8 blendingEnabled
         {
             get => bool8_objc_msgSend(NativePtr, sel_isBlendingEnabled);
@@ -61,6 +67,8 @@ namespace Veldrid.MetalBindings
 
         private static readonly Selector sel_isBlendingEnabled = "isBlendingEnabled";
         private static readonly Selector sel_setBlendingEnabled = "setBlendingEnabled:";
+        private static readonly Selector sel_writeMask = "writeMask";
+        private static readonly Selector sel_setWriteMask = "setWriteMask:";
         private static readonly Selector sel_alphaBlendOperation = "alphaBlendOperation";
         private static readonly Selector sel_setAlphaBlendOperation = "setAlphaBlendOperation:";
         private static readonly Selector sel_rgbBlendOperation = "rgbBlendOperation";

--- a/src/Veldrid.OpenGLBindings/OpenGLNative.cs
+++ b/src/Veldrid.OpenGLBindings/OpenGLNative.cs
@@ -437,6 +437,34 @@ namespace Veldrid.OpenGLBinding
         public static void glDeleteSamplers(uint n, ref uint samplers) => p_glDeleteSamplers(n, ref samplers);
 
         [UnmanagedFunctionPointer(CallConv)]
+        private delegate void glColorMask_t(
+            GLboolean red,
+            GLboolean green,
+            GLboolean blue,
+            GLboolean alpha);
+        private static glColorMask_t p_glColorMask;
+        public static void glColorMask(
+            GLboolean red,
+            GLboolean green,
+            GLboolean blue,
+            GLboolean alpha) => p_glColorMask(red, green, blue, alpha);
+
+        [UnmanagedFunctionPointer(CallConv)]
+        private delegate void glColorMaski_t(
+            uint buf,
+            GLboolean red,
+            GLboolean green,
+            GLboolean blue,
+            GLboolean alpha);
+        private static glColorMaski_t p_glColorMaski;
+        public static void glColorMaski(
+            uint buf,
+            GLboolean red,
+            GLboolean green,
+            GLboolean blue,
+            GLboolean alpha) => p_glColorMaski(buf, red, green, blue, alpha);
+
+        [UnmanagedFunctionPointer(CallConv)]
         private delegate void glBlendFuncSeparatei_t(
             uint buf,
             BlendingFactorSrc srcRGB,
@@ -1767,6 +1795,8 @@ namespace Veldrid.OpenGLBinding
             LoadFunction("glSamplerParameterfv", out p_glSamplerParameterfv);
             LoadFunction("glBindSampler", out p_glBindSampler);
             LoadFunction("glDeleteSamplers", out p_glDeleteSamplers);
+            LoadFunction("glColorMaski", out p_glColorMaski);
+            LoadFunction("glColorMask", out p_glColorMask);
             LoadFunction("glBlendFuncSeparatei", out p_glBlendFuncSeparatei);
             LoadFunction("glBlendFuncSeparate", out p_glBlendFuncSeparate);
             LoadFunction("glEnable", out p_glEnable);

--- a/src/Veldrid/BlendAttachmentDescription.cs
+++ b/src/Veldrid/BlendAttachmentDescription.cs
@@ -12,6 +12,10 @@ namespace Veldrid
         /// </summary>
         public bool BlendEnabled;
         /// <summary>
+        /// Controls which components of the color will be written to the framebuffer.
+        /// </summary>
+        public ColorWriteMask ColorWriteMask;
+        /// <summary>
         /// Controls the source color's influence on the blend result.
         /// </summary>
         public BlendFactor SourceColorFactor;
@@ -62,12 +66,45 @@ namespace Veldrid
             SourceAlphaFactor = sourceAlphaFactor;
             DestinationAlphaFactor = destinationAlphaFactor;
             AlphaFunction = alphaFunction;
+            ColorWriteMask = ColorWriteMask.All;
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="BlendAttachmentDescription"/>.
+        /// </summary>
+        /// <param name="blendEnabled">Controls whether blending is enabled for the color attachment.</param>
+        /// <param name="colorWriteMask">Controls which components of the color will be written to the framebuffer.</param>
+        /// <param name="sourceColorFactor">Controls the source color's influence on the blend result.</param>
+        /// <param name="destinationColorFactor">Controls the destination color's influence on the blend result.</param>
+        /// <param name="colorFunction">Controls the function used to combine the source and destination color factors.</param>
+        /// <param name="sourceAlphaFactor">Controls the source alpha's influence on the blend result.</param>
+        /// <param name="destinationAlphaFactor">Controls the destination alpha's influence on the blend result.</param>
+        /// <param name="alphaFunction">Controls the function used to combine the source and destination alpha factors.</param>
+        public BlendAttachmentDescription(
+            bool blendEnabled,
+            ColorWriteMask colorWriteMask,
+            BlendFactor sourceColorFactor,
+            BlendFactor destinationColorFactor,
+            BlendFunction colorFunction,
+            BlendFactor sourceAlphaFactor,
+            BlendFactor destinationAlphaFactor,
+            BlendFunction alphaFunction)
+        {
+            BlendEnabled = blendEnabled;
+            ColorWriteMask = colorWriteMask;
+            SourceColorFactor = sourceColorFactor;
+            DestinationColorFactor = destinationColorFactor;
+            ColorFunction = colorFunction;
+            SourceAlphaFactor = sourceAlphaFactor;
+            DestinationAlphaFactor = destinationAlphaFactor;
+            AlphaFunction = alphaFunction;
         }
 
         /// <summary>
         /// Describes a blend attachment state in which the source completely overrides the destination.
         /// Settings:
         ///     BlendEnabled = true
+        ///     ColorWriteMask = ColorWriteMask.All
         ///     SourceColorFactor = BlendFactor.One
         ///     DestinationColorFactor = BlendFactor.Zero
         ///     ColorFunction = BlendFunction.Add
@@ -78,6 +115,7 @@ namespace Veldrid
         public static readonly BlendAttachmentDescription OverrideBlend = new BlendAttachmentDescription
         {
             BlendEnabled = true,
+            ColorWriteMask = ColorWriteMask.All,
             SourceColorFactor = BlendFactor.One,
             DestinationColorFactor = BlendFactor.Zero,
             ColorFunction = BlendFunction.Add,
@@ -90,6 +128,7 @@ namespace Veldrid
         /// Describes a blend attachment state in which the source and destination are blended in an inverse relationship.
         /// Settings:
         ///     BlendEnabled = true
+        ///     ColorWriteMask = ColorWriteMask.All
         ///     SourceColorFactor = BlendFactor.SourceAlpha
         ///     DestinationColorFactor = BlendFactor.InverseSourceAlpha
         ///     ColorFunction = BlendFunction.Add
@@ -100,6 +139,7 @@ namespace Veldrid
         public static readonly BlendAttachmentDescription AlphaBlend = new BlendAttachmentDescription
         {
             BlendEnabled = true,
+            ColorWriteMask = ColorWriteMask.All,
             SourceColorFactor = BlendFactor.SourceAlpha,
             DestinationColorFactor = BlendFactor.InverseSourceAlpha,
             ColorFunction = BlendFunction.Add,
@@ -112,6 +152,7 @@ namespace Veldrid
         /// Describes a blend attachment state in which the source is added to the destination based on its alpha channel.
         /// Settings:
         ///     BlendEnabled = true
+        ///     ColorWriteMask = ColorWriteMask.All
         ///     SourceColorFactor = BlendFactor.SourceAlpha
         ///     DestinationColorFactor = BlendFactor.One
         ///     ColorFunction = BlendFunction.Add
@@ -122,6 +163,7 @@ namespace Veldrid
         public static readonly BlendAttachmentDescription AdditiveBlend = new BlendAttachmentDescription
         {
             BlendEnabled = true,
+            ColorWriteMask = ColorWriteMask.All,
             SourceColorFactor = BlendFactor.SourceAlpha,
             DestinationColorFactor = BlendFactor.One,
             ColorFunction = BlendFunction.Add,
@@ -134,6 +176,7 @@ namespace Veldrid
         /// Describes a blend attachment state in which blending is disabled.
         /// Settings:
         ///     BlendEnabled = false
+        ///     ColorWriteMask = ColorWriteMask.All
         ///     SourceColorFactor = BlendFactor.One
         ///     DestinationColorFactor = BlendFactor.Zero
         ///     ColorFunction = BlendFunction.Add
@@ -144,6 +187,7 @@ namespace Veldrid
         public static readonly BlendAttachmentDescription Disabled = new BlendAttachmentDescription
         {
             BlendEnabled = false,
+            ColorWriteMask = ColorWriteMask.All,
             SourceColorFactor = BlendFactor.One,
             DestinationColorFactor = BlendFactor.Zero,
             ColorFunction = BlendFunction.Add,
@@ -159,7 +203,9 @@ namespace Veldrid
         /// <returns>True if all elements and all array elements are equal; false otherswise.</returns>
         public bool Equals(BlendAttachmentDescription other)
         {
-            return BlendEnabled.Equals(other.BlendEnabled) && SourceColorFactor == other.SourceColorFactor
+            return BlendEnabled.Equals(other.BlendEnabled)
+                && ColorWriteMask.Equals(other.ColorWriteMask)
+                && SourceColorFactor == other.SourceColorFactor
                 && DestinationColorFactor == other.DestinationColorFactor && ColorFunction == other.ColorFunction
                 && SourceAlphaFactor == other.SourceAlphaFactor && DestinationAlphaFactor == other.DestinationAlphaFactor
                 && AlphaFunction == other.AlphaFunction;
@@ -173,6 +219,7 @@ namespace Veldrid
         {
             return HashHelper.Combine(
                 BlendEnabled.GetHashCode(),
+                (int)ColorWriteMask,
                 (int)SourceColorFactor,
                 (int)DestinationColorFactor,
                 (int)ColorFunction,

--- a/src/Veldrid/BlendAttachmentDescription.cs
+++ b/src/Veldrid/BlendAttachmentDescription.cs
@@ -13,8 +13,9 @@ namespace Veldrid
         public bool BlendEnabled;
         /// <summary>
         /// Controls which components of the color will be written to the framebuffer.
+        /// If <c>null</c>, the mask will be set to <see cref="Veldrid.ColorWriteMask.All"/>.
         /// </summary>
-        public ColorWriteMask ColorWriteMask;
+        public ColorWriteMask? ColorWriteMask;
         /// <summary>
         /// Controls the source color's influence on the blend result.
         /// </summary>
@@ -66,7 +67,7 @@ namespace Veldrid
             SourceAlphaFactor = sourceAlphaFactor;
             DestinationAlphaFactor = destinationAlphaFactor;
             AlphaFunction = alphaFunction;
-            ColorWriteMask = ColorWriteMask.All;
+            ColorWriteMask = null;
         }
 
         /// <summary>
@@ -104,7 +105,7 @@ namespace Veldrid
         /// Describes a blend attachment state in which the source completely overrides the destination.
         /// Settings:
         ///     BlendEnabled = true
-        ///     ColorWriteMask = ColorWriteMask.All
+        ///     ColorWriteMask = null
         ///     SourceColorFactor = BlendFactor.One
         ///     DestinationColorFactor = BlendFactor.Zero
         ///     ColorFunction = BlendFunction.Add
@@ -115,7 +116,6 @@ namespace Veldrid
         public static readonly BlendAttachmentDescription OverrideBlend = new BlendAttachmentDescription
         {
             BlendEnabled = true,
-            ColorWriteMask = ColorWriteMask.All,
             SourceColorFactor = BlendFactor.One,
             DestinationColorFactor = BlendFactor.Zero,
             ColorFunction = BlendFunction.Add,
@@ -128,7 +128,7 @@ namespace Veldrid
         /// Describes a blend attachment state in which the source and destination are blended in an inverse relationship.
         /// Settings:
         ///     BlendEnabled = true
-        ///     ColorWriteMask = ColorWriteMask.All
+        ///     ColorWriteMask = null
         ///     SourceColorFactor = BlendFactor.SourceAlpha
         ///     DestinationColorFactor = BlendFactor.InverseSourceAlpha
         ///     ColorFunction = BlendFunction.Add
@@ -139,7 +139,6 @@ namespace Veldrid
         public static readonly BlendAttachmentDescription AlphaBlend = new BlendAttachmentDescription
         {
             BlendEnabled = true,
-            ColorWriteMask = ColorWriteMask.All,
             SourceColorFactor = BlendFactor.SourceAlpha,
             DestinationColorFactor = BlendFactor.InverseSourceAlpha,
             ColorFunction = BlendFunction.Add,
@@ -152,7 +151,7 @@ namespace Veldrid
         /// Describes a blend attachment state in which the source is added to the destination based on its alpha channel.
         /// Settings:
         ///     BlendEnabled = true
-        ///     ColorWriteMask = ColorWriteMask.All
+        ///     ColorWriteMask = null
         ///     SourceColorFactor = BlendFactor.SourceAlpha
         ///     DestinationColorFactor = BlendFactor.One
         ///     ColorFunction = BlendFunction.Add
@@ -163,7 +162,6 @@ namespace Veldrid
         public static readonly BlendAttachmentDescription AdditiveBlend = new BlendAttachmentDescription
         {
             BlendEnabled = true,
-            ColorWriteMask = ColorWriteMask.All,
             SourceColorFactor = BlendFactor.SourceAlpha,
             DestinationColorFactor = BlendFactor.One,
             ColorFunction = BlendFunction.Add,
@@ -176,7 +174,7 @@ namespace Veldrid
         /// Describes a blend attachment state in which blending is disabled.
         /// Settings:
         ///     BlendEnabled = false
-        ///     ColorWriteMask = ColorWriteMask.All
+        ///     ColorWriteMask = null
         ///     SourceColorFactor = BlendFactor.One
         ///     DestinationColorFactor = BlendFactor.Zero
         ///     ColorFunction = BlendFunction.Add
@@ -187,7 +185,6 @@ namespace Veldrid
         public static readonly BlendAttachmentDescription Disabled = new BlendAttachmentDescription
         {
             BlendEnabled = false,
-            ColorWriteMask = ColorWriteMask.All,
             SourceColorFactor = BlendFactor.One,
             DestinationColorFactor = BlendFactor.Zero,
             ColorFunction = BlendFunction.Add,
@@ -219,7 +216,7 @@ namespace Veldrid
         {
             return HashHelper.Combine(
                 BlendEnabled.GetHashCode(),
-                (int)ColorWriteMask,
+                ColorWriteMask.GetHashCode(),
                 (int)SourceColorFactor,
                 (int)DestinationColorFactor,
                 (int)ColorFunction,

--- a/src/Veldrid/BlendHelper.cs
+++ b/src/Veldrid/BlendHelper.cs
@@ -1,0 +1,12 @@
+namespace Veldrid
+{
+    internal static class BlendHelper
+    {
+        /// <summary>
+        /// Given a nullable <see cref="ColorWriteMask"/>, returns the mask as non-null, or <see cref="ColorWriteMask.All"/> if null.
+        /// </summary>
+        /// <param name="mask">A nullable mask.</param>
+        /// <returns>The non-nullable mask.</returns>
+        public static ColorWriteMask GetOrDefault(this ColorWriteMask? mask) => mask ?? ColorWriteMask.All;
+    }
+}

--- a/src/Veldrid/ColorWriteMask.cs
+++ b/src/Veldrid/ColorWriteMask.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Veldrid
+{
+    /// <summary>
+    /// A color bitmask representing the components which can be written to.
+    /// </summary>
+    [Flags]
+    public enum ColorWriteMask
+    {
+        /// <summary>
+        /// No color component will be written to.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The red component will be written to.
+        /// </summary>
+        Red = 1 << 0,
+
+        /// <summary>
+        /// The green component will be written to.
+        /// </summary>
+        Green = 1 << 1,
+
+        /// <summary>
+        /// The blue component will be written to.
+        /// </summary>
+        Blue = 1 << 2,
+
+        /// <summary>
+        /// The alpha component will be written to.
+        /// </summary>
+        Alpha = 1 << 3,
+
+        /// <summary>
+        /// All color components will be written to.
+        /// </summary>
+        All = Red | Green | Blue,
+    }
+}

--- a/src/Veldrid/ColorWriteMask.cs
+++ b/src/Veldrid/ColorWriteMask.cs
@@ -36,6 +36,6 @@ namespace Veldrid
         /// <summary>
         /// All color components will be written to.
         /// </summary>
-        All = Red | Green | Blue,
+        All = Red | Green | Blue | Alpha,
     }
 }

--- a/src/Veldrid/D3D11/D3D11Formats.cs
+++ b/src/Veldrid/D3D11/D3D11Formats.cs
@@ -560,6 +560,22 @@ namespace Veldrid.D3D11
             }
         }
 
+        internal static ColorWriteEnable VdToD3D11ColorWriteEnable(ColorWriteMask mask)
+        {
+            ColorWriteEnable enable = ColorWriteEnable.None;
+
+            if ((mask & ColorWriteMask.Red) == ColorWriteMask.Red)
+                enable |= ColorWriteEnable.Red;
+            if ((mask & ColorWriteMask.Green) == ColorWriteMask.Green)
+                enable |= ColorWriteEnable.Green;
+            if ((mask & ColorWriteMask.Blue) == ColorWriteMask.Blue)
+                enable |= ColorWriteEnable.Blue;
+            if ((mask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha)
+                enable |= ColorWriteEnable.Alpha;
+
+            return enable;
+        }
+
         internal static Filter ToD3D11Filter(SamplerFilter filter, bool isComparison)
         {
             switch (filter)

--- a/src/Veldrid/D3D11/D3D11ResourceCache.cs
+++ b/src/Veldrid/D3D11/D3D11ResourceCache.cs
@@ -72,7 +72,7 @@ namespace Veldrid.D3D11
             {
                 BlendAttachmentDescription state = attachmentStates[i];
                 d3dBlendStateDesc.RenderTarget[i].IsBlendEnabled = state.BlendEnabled;
-                d3dBlendStateDesc.RenderTarget[i].RenderTargetWriteMask = ColorWriteEnable.All;
+                d3dBlendStateDesc.RenderTarget[i].RenderTargetWriteMask = D3D11Formats.VdToD3D11ColorWriteEnable(state.ColorWriteMask);
                 d3dBlendStateDesc.RenderTarget[i].SourceBlend = D3D11Formats.VdToD3D11Blend(state.SourceColorFactor);
                 d3dBlendStateDesc.RenderTarget[i].DestinationBlend = D3D11Formats.VdToD3D11Blend(state.DestinationColorFactor);
                 d3dBlendStateDesc.RenderTarget[i].BlendOperation = D3D11Formats.VdToD3D11BlendOperation(state.ColorFunction);

--- a/src/Veldrid/D3D11/D3D11ResourceCache.cs
+++ b/src/Veldrid/D3D11/D3D11ResourceCache.cs
@@ -72,7 +72,7 @@ namespace Veldrid.D3D11
             {
                 BlendAttachmentDescription state = attachmentStates[i];
                 d3dBlendStateDesc.RenderTarget[i].IsBlendEnabled = state.BlendEnabled;
-                d3dBlendStateDesc.RenderTarget[i].RenderTargetWriteMask = D3D11Formats.VdToD3D11ColorWriteEnable(state.ColorWriteMask);
+                d3dBlendStateDesc.RenderTarget[i].RenderTargetWriteMask = D3D11Formats.VdToD3D11ColorWriteEnable(state.ColorWriteMask.GetOrDefault());
                 d3dBlendStateDesc.RenderTarget[i].SourceBlend = D3D11Formats.VdToD3D11Blend(state.SourceColorFactor);
                 d3dBlendStateDesc.RenderTarget[i].DestinationBlend = D3D11Formats.VdToD3D11Blend(state.DestinationColorFactor);
                 d3dBlendStateDesc.RenderTarget[i].BlendOperation = D3D11Formats.VdToD3D11BlendOperation(state.ColorFunction);

--- a/src/Veldrid/MTL/MTLFormats.cs
+++ b/src/Veldrid/MTL/MTLFormats.cs
@@ -344,6 +344,22 @@ namespace Veldrid.MTL
             }
         }
 
+        internal static MTLColorWriteMask VdToMTLColorWriteMask(ColorWriteMask vdMask)
+        {
+            MTLColorWriteMask mask = MTLColorWriteMask.None;
+
+            if ((vdMask & ColorWriteMask.Red) == ColorWriteMask.Red)
+                mask |= MTLColorWriteMask.Red;
+            if ((vdMask & ColorWriteMask.Green) == ColorWriteMask.Green)
+                mask |= MTLColorWriteMask.Green;
+            if ((vdMask & ColorWriteMask.Blue) == ColorWriteMask.Blue)
+                mask |= MTLColorWriteMask.Blue;
+            if ((vdMask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha)
+                mask |= MTLColorWriteMask.Alpha;
+
+            return mask;
+        }
+
         internal static MTLDataType VdVoMTLShaderConstantType(ShaderConstantType type)
         {
             switch (type)

--- a/src/Veldrid/MTL/MTLPipeline.cs
+++ b/src/Veldrid/MTL/MTLPipeline.cs
@@ -144,6 +144,7 @@ namespace Veldrid.MTL
                 MTLRenderPipelineColorAttachmentDescriptor colorDesc = mtlDesc.colorAttachments[i];
                 colorDesc.pixelFormat = MTLFormats.VdToMTLPixelFormat(outputs.ColorAttachments[i].Format, false);
                 colorDesc.blendingEnabled = attachmentBlendDesc.BlendEnabled;
+                colorDesc.writeMask = MTLFormats.VdToMTLColorWriteMask(attachmentBlendDesc.ColorWriteMask);
                 colorDesc.alphaBlendOperation = MTLFormats.VdToMTLBlendOp(attachmentBlendDesc.AlphaFunction);
                 colorDesc.sourceAlphaBlendFactor = MTLFormats.VdToMTLBlendFactor(attachmentBlendDesc.SourceAlphaFactor);
                 colorDesc.destinationAlphaBlendFactor = MTLFormats.VdToMTLBlendFactor(attachmentBlendDesc.DestinationAlphaFactor);

--- a/src/Veldrid/MTL/MTLPipeline.cs
+++ b/src/Veldrid/MTL/MTLPipeline.cs
@@ -144,7 +144,7 @@ namespace Veldrid.MTL
                 MTLRenderPipelineColorAttachmentDescriptor colorDesc = mtlDesc.colorAttachments[i];
                 colorDesc.pixelFormat = MTLFormats.VdToMTLPixelFormat(outputs.ColorAttachments[i].Format, false);
                 colorDesc.blendingEnabled = attachmentBlendDesc.BlendEnabled;
-                colorDesc.writeMask = MTLFormats.VdToMTLColorWriteMask(attachmentBlendDesc.ColorWriteMask);
+                colorDesc.writeMask = MTLFormats.VdToMTLColorWriteMask(attachmentBlendDesc.ColorWriteMask.GetOrDefault());
                 colorDesc.alphaBlendOperation = MTLFormats.VdToMTLBlendOp(attachmentBlendDesc.AlphaFunction);
                 colorDesc.sourceAlphaBlendFactor = MTLFormats.VdToMTLBlendFactor(attachmentBlendDesc.SourceAlphaFactor);
                 colorDesc.destinationAlphaBlendFactor = MTLFormats.VdToMTLBlendFactor(attachmentBlendDesc.DestinationAlphaFactor);

--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -508,13 +508,14 @@ namespace Veldrid.OpenGL
                 for (uint i = 0; i < blendState.AttachmentStates.Length; i++)
                 {
                     BlendAttachmentDescription attachment = blendState.AttachmentStates[i];
+                    ColorWriteMask colorMask = attachment.ColorWriteMask.GetOrDefault();
 
                     glColorMaski(
                         i,
-                        (attachment.ColorWriteMask & ColorWriteMask.Red) == ColorWriteMask.Red,
-                        (attachment.ColorWriteMask & ColorWriteMask.Green) == ColorWriteMask.Green,
-                        (attachment.ColorWriteMask & ColorWriteMask.Blue) == ColorWriteMask.Blue,
-                        (attachment.ColorWriteMask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha);
+                        (colorMask & ColorWriteMask.Red) == ColorWriteMask.Red,
+                        (colorMask & ColorWriteMask.Green) == ColorWriteMask.Green,
+                        (colorMask & ColorWriteMask.Blue) == ColorWriteMask.Blue,
+                        (colorMask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha);
                     CheckLastError();
 
                     if (!attachment.BlendEnabled)
@@ -546,12 +547,13 @@ namespace Veldrid.OpenGL
             else if (blendState.AttachmentStates.Length > 0)
             {
                 BlendAttachmentDescription attachment = blendState.AttachmentStates[0];
+                ColorWriteMask colorMask = attachment.ColorWriteMask.GetOrDefault();
 
                 glColorMask(
-                    (attachment.ColorWriteMask & ColorWriteMask.Red) == ColorWriteMask.Red,
-                    (attachment.ColorWriteMask & ColorWriteMask.Green) == ColorWriteMask.Green,
-                    (attachment.ColorWriteMask & ColorWriteMask.Blue) == ColorWriteMask.Blue,
-                    (attachment.ColorWriteMask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha);
+                    (colorMask & ColorWriteMask.Red) == ColorWriteMask.Red,
+                    (colorMask & ColorWriteMask.Green) == ColorWriteMask.Green,
+                    (colorMask & ColorWriteMask.Blue) == ColorWriteMask.Blue,
+                    (colorMask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha);
                 CheckLastError();
 
                 if (!attachment.BlendEnabled)

--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -508,6 +508,7 @@ namespace Veldrid.OpenGL
                 for (uint i = 0; i < blendState.AttachmentStates.Length; i++)
                 {
                     BlendAttachmentDescription attachment = blendState.AttachmentStates[i];
+
                     if (!attachment.BlendEnabled)
                     {
                         glDisablei(EnableCap.Blend, i);
@@ -516,6 +517,14 @@ namespace Veldrid.OpenGL
                     else
                     {
                         glEnablei(EnableCap.Blend, i);
+                        CheckLastError();
+
+                        glColorMaski(
+                            i,
+                            (attachment.ColorWriteMask & ColorWriteMask.Red) == ColorWriteMask.Red,
+                            (attachment.ColorWriteMask & ColorWriteMask.Green) == ColorWriteMask.Green,
+                            (attachment.ColorWriteMask & ColorWriteMask.Blue) == ColorWriteMask.Blue,
+                            (attachment.ColorWriteMask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha);
                         CheckLastError();
 
                         glBlendFuncSeparatei(
@@ -545,6 +554,13 @@ namespace Veldrid.OpenGL
                 else
                 {
                     glEnable(EnableCap.Blend);
+                    CheckLastError();
+
+                    glColorMask(
+                        (attachment.ColorWriteMask & ColorWriteMask.Red) == ColorWriteMask.Red,
+                        (attachment.ColorWriteMask & ColorWriteMask.Green) == ColorWriteMask.Green,
+                        (attachment.ColorWriteMask & ColorWriteMask.Blue) == ColorWriteMask.Blue,
+                        (attachment.ColorWriteMask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha);
                     CheckLastError();
 
                     glBlendFuncSeparate(

--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -509,6 +509,14 @@ namespace Veldrid.OpenGL
                 {
                     BlendAttachmentDescription attachment = blendState.AttachmentStates[i];
 
+                    glColorMaski(
+                        i,
+                        (attachment.ColorWriteMask & ColorWriteMask.Red) == ColorWriteMask.Red,
+                        (attachment.ColorWriteMask & ColorWriteMask.Green) == ColorWriteMask.Green,
+                        (attachment.ColorWriteMask & ColorWriteMask.Blue) == ColorWriteMask.Blue,
+                        (attachment.ColorWriteMask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha);
+                    CheckLastError();
+
                     if (!attachment.BlendEnabled)
                     {
                         glDisablei(EnableCap.Blend, i);
@@ -517,14 +525,6 @@ namespace Veldrid.OpenGL
                     else
                     {
                         glEnablei(EnableCap.Blend, i);
-                        CheckLastError();
-
-                        glColorMaski(
-                            i,
-                            (attachment.ColorWriteMask & ColorWriteMask.Red) == ColorWriteMask.Red,
-                            (attachment.ColorWriteMask & ColorWriteMask.Green) == ColorWriteMask.Green,
-                            (attachment.ColorWriteMask & ColorWriteMask.Blue) == ColorWriteMask.Blue,
-                            (attachment.ColorWriteMask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha);
                         CheckLastError();
 
                         glBlendFuncSeparatei(
@@ -546,6 +546,14 @@ namespace Veldrid.OpenGL
             else if (blendState.AttachmentStates.Length > 0)
             {
                 BlendAttachmentDescription attachment = blendState.AttachmentStates[0];
+
+                glColorMask(
+                    (attachment.ColorWriteMask & ColorWriteMask.Red) == ColorWriteMask.Red,
+                    (attachment.ColorWriteMask & ColorWriteMask.Green) == ColorWriteMask.Green,
+                    (attachment.ColorWriteMask & ColorWriteMask.Blue) == ColorWriteMask.Blue,
+                    (attachment.ColorWriteMask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha);
+                CheckLastError();
+
                 if (!attachment.BlendEnabled)
                 {
                     glDisable(EnableCap.Blend);
@@ -554,13 +562,6 @@ namespace Veldrid.OpenGL
                 else
                 {
                     glEnable(EnableCap.Blend);
-                    CheckLastError();
-
-                    glColorMask(
-                        (attachment.ColorWriteMask & ColorWriteMask.Red) == ColorWriteMask.Red,
-                        (attachment.ColorWriteMask & ColorWriteMask.Green) == ColorWriteMask.Green,
-                        (attachment.ColorWriteMask & ColorWriteMask.Blue) == ColorWriteMask.Blue,
-                        (attachment.ColorWriteMask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha);
                     CheckLastError();
 
                     glBlendFuncSeparate(

--- a/src/Veldrid/Vk/VkFormats.cs
+++ b/src/Veldrid/Vk/VkFormats.cs
@@ -236,6 +236,22 @@ namespace Veldrid.Vk
             }
         }
 
+        internal static VkColorComponentFlags VdToVkColorWriteMask(ColorWriteMask mask)
+        {
+            VkColorComponentFlags flags = VkColorComponentFlags.None;
+
+            if ((mask & ColorWriteMask.Red) == ColorWriteMask.Red)
+                flags |= VkColorComponentFlags.R;
+            if ((mask & ColorWriteMask.Green) == ColorWriteMask.Green)
+                flags |= VkColorComponentFlags.G;
+            if ((mask & ColorWriteMask.Blue) == ColorWriteMask.Blue)
+                flags |= VkColorComponentFlags.B;
+            if ((mask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha)
+                flags |= VkColorComponentFlags.A;
+
+            return flags;
+        }
+
         internal static VkPrimitiveTopology VdToVkPrimitiveTopology(PrimitiveTopology topology)
         {
             switch (topology)

--- a/src/Veldrid/Vk/VkPipeline.cs
+++ b/src/Veldrid/Vk/VkPipeline.cs
@@ -54,7 +54,7 @@ namespace Veldrid.Vk
                 attachmentState.srcAlphaBlendFactor = VkFormats.VdToVkBlendFactor(vdDesc.SourceAlphaFactor);
                 attachmentState.dstAlphaBlendFactor = VkFormats.VdToVkBlendFactor(vdDesc.DestinationAlphaFactor);
                 attachmentState.alphaBlendOp = VkFormats.VdToVkBlendOp(vdDesc.AlphaFunction);
-                attachmentState.colorWriteMask = VkFormats.VdToVkColorWriteMask(vdDesc.ColorWriteMask);
+                attachmentState.colorWriteMask = VkFormats.VdToVkColorWriteMask(vdDesc.ColorWriteMask.GetOrDefault());
                 attachmentState.blendEnable = vdDesc.BlendEnabled;
                 attachmentsPtr[i] = attachmentState;
             }

--- a/src/Veldrid/Vk/VkPipeline.cs
+++ b/src/Veldrid/Vk/VkPipeline.cs
@@ -54,8 +54,8 @@ namespace Veldrid.Vk
                 attachmentState.srcAlphaBlendFactor = VkFormats.VdToVkBlendFactor(vdDesc.SourceAlphaFactor);
                 attachmentState.dstAlphaBlendFactor = VkFormats.VdToVkBlendFactor(vdDesc.DestinationAlphaFactor);
                 attachmentState.alphaBlendOp = VkFormats.VdToVkBlendOp(vdDesc.AlphaFunction);
+                attachmentState.colorWriteMask = VkFormats.VdToVkColorWriteMask(vdDesc.ColorWriteMask);
                 attachmentState.blendEnable = vdDesc.BlendEnabled;
-                attachmentState.colorWriteMask = VkColorComponentFlags.R | VkColorComponentFlags.G | VkColorComponentFlags.B | VkColorComponentFlags.A;
                 attachmentsPtr[i] = attachmentState;
             }
 


### PR DESCRIPTION
I was relying on `BlendFactor` at first, but turns out that doesn't really play well with OpenGL. So I looked at adding support for color write masks instead, which exists in all graphics APIs and is fairly simple to implement.