### PR TITLE
Update ImageSharp from 1.0.4 to 2.1.0

### DIFF
--- a/src/Veldrid.ImageSharp/ImageSharpCubemapTexture.cs
+++ b/src/Veldrid.ImageSharp/ImageSharpCubemapTexture.cs
@@ -1,9 +1,8 @@
 ﻿using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using System;
+using System.Buffers;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Veldrid.ImageSharp
 {
@@ -171,47 +170,47 @@ namespace Veldrid.ImageSharp
 
             for (int level = 0; level < MipLevels; level++)
             {
-                if (!CubemapTextures[PositiveXArrayLayer][level].TryGetSinglePixelSpan(out Span<Rgba32> pixelSpanPosX))
+                if (!CubemapTextures[PositiveXArrayLayer][level].DangerousTryGetSinglePixelMemory(out Memory<Rgba32> pixelMemoryPosX))
                 {
-                    throw new VeldridException("Unable to get positive x pixelspan.");
+                    throw new VeldridException("Unable to get positive x pixelspan. Make sure to initialize MemoryAllocator.Default!");
                 }
-                if (!CubemapTextures[NegativeXArrayLayer][level].TryGetSinglePixelSpan(out Span<Rgba32> pixelSpanNegX))
+                if (!CubemapTextures[NegativeXArrayLayer][level].DangerousTryGetSinglePixelMemory(out Memory<Rgba32> pixelMemoryNegX))
                 {
-                    throw new VeldridException("Unable to get negatve x pixelspan.");
+                    throw new VeldridException("Unable to get negatve x pixelspan. Make sure to initialize MemoryAllocator.Default!");
                 }
-                if (!CubemapTextures[PositiveYArrayLayer][level].TryGetSinglePixelSpan(out Span<Rgba32> pixelSpanPosY))
+                if (!CubemapTextures[PositiveYArrayLayer][level].DangerousTryGetSinglePixelMemory(out Memory<Rgba32> pixelMemoryPosY))
                 {
-                    throw new VeldridException("Unable to get positive y pixelspan.");
+                    throw new VeldridException("Unable to get positive y pixelspan. Make sure to initialize MemoryAllocator.Default!");
                 }
-                if (!CubemapTextures[NegativeYArrayLayer][level].TryGetSinglePixelSpan(out Span<Rgba32> pixelSpanNegY))
+                if (!CubemapTextures[NegativeYArrayLayer][level].DangerousTryGetSinglePixelMemory(out Memory<Rgba32> pixelMemoryNegY))
                 {
-                    throw new VeldridException("Unable to get negatve y pixelspan.");
+                    throw new VeldridException("Unable to get negatve y pixelspan. Make sure to initialize MemoryAllocator.Default!");
                 }
-                if (!CubemapTextures[PositiveZArrayLayer][level].TryGetSinglePixelSpan(out Span<Rgba32> pixelSpanPosZ))
+                if (!CubemapTextures[PositiveZArrayLayer][level].DangerousTryGetSinglePixelMemory(out Memory<Rgba32> pixelMemoryPosZ))
                 {
-                    throw new VeldridException("Unable to get positive z pixelspan."); 
+                    throw new VeldridException("Unable to get positive z pixelspan. Make sure to initialize MemoryAllocator.Default!"); 
                 }
-                if (!CubemapTextures[NegativeZArrayLayer][level].TryGetSinglePixelSpan(out Span<Rgba32> pixelSpanNegZ))
+                if (!CubemapTextures[NegativeZArrayLayer][level].DangerousTryGetSinglePixelMemory(out Memory<Rgba32> pixelMemoryNegZ))
                 {
-                    throw new VeldridException("Unable to get negatve z pixelspan.");
+                    throw new VeldridException("Unable to get negatve z pixelspan. Make sure to initialize MemoryAllocator.Default!");
                 }
-                fixed (Rgba32* positiveXPin = &MemoryMarshal.GetReference(pixelSpanPosX))
-                fixed (Rgba32* negativeXPin = &MemoryMarshal.GetReference(pixelSpanNegX))
-                fixed (Rgba32* positiveYPin = &MemoryMarshal.GetReference(pixelSpanPosY))
-                fixed (Rgba32* negativeYPin = &MemoryMarshal.GetReference(pixelSpanNegY))
-                fixed (Rgba32* positiveZPin = &MemoryMarshal.GetReference(pixelSpanPosZ))
-                fixed (Rgba32* negativeZPin = &MemoryMarshal.GetReference(pixelSpanNegZ))
+                using (MemoryHandle positiveXPin = pixelMemoryPosX.Pin())
+                using (MemoryHandle negativeXPin = pixelMemoryNegX.Pin())
+                using (MemoryHandle positiveYPin = pixelMemoryPosY.Pin())
+                using (MemoryHandle negativeYPin = pixelMemoryNegY.Pin())
+                using (MemoryHandle positiveZPin = pixelMemoryPosZ.Pin())
+                using (MemoryHandle negativeZPin = pixelMemoryNegZ.Pin())
                 {
                     Image<Rgba32> image = CubemapTextures[0][level];
                     uint width = (uint)image.Width;
                     uint height = (uint)image.Height;
                     uint faceSize = width * height * PixelSizeInBytes;
-                    gd.UpdateTexture(cubemapTexture, (IntPtr)positiveXPin, faceSize, 0, 0, 0, width, height, 1, (uint)level, PositiveXArrayLayer);
-                    gd.UpdateTexture(cubemapTexture, (IntPtr)negativeXPin, faceSize, 0, 0, 0, width, height, 1, (uint)level, NegativeXArrayLayer);
-                    gd.UpdateTexture(cubemapTexture, (IntPtr)positiveYPin, faceSize, 0, 0, 0, width, height, 1, (uint)level, PositiveYArrayLayer);
-                    gd.UpdateTexture(cubemapTexture, (IntPtr)negativeYPin, faceSize, 0, 0, 0, width, height, 1, (uint)level, NegativeYArrayLayer);
-                    gd.UpdateTexture(cubemapTexture, (IntPtr)positiveZPin, faceSize, 0, 0, 0, width, height, 1, (uint)level, PositiveZArrayLayer);
-                    gd.UpdateTexture(cubemapTexture, (IntPtr)negativeZPin, faceSize, 0, 0, 0, width, height, 1, (uint)level, NegativeZArrayLayer);
+                    gd.UpdateTexture(cubemapTexture, (IntPtr)positiveXPin.Pointer, faceSize, 0, 0, 0, width, height, 1, (uint)level, PositiveXArrayLayer);
+                    gd.UpdateTexture(cubemapTexture, (IntPtr)negativeXPin.Pointer, faceSize, 0, 0, 0, width, height, 1, (uint)level, NegativeXArrayLayer);
+                    gd.UpdateTexture(cubemapTexture, (IntPtr)positiveYPin.Pointer, faceSize, 0, 0, 0, width, height, 1, (uint)level, PositiveYArrayLayer);
+                    gd.UpdateTexture(cubemapTexture, (IntPtr)negativeYPin.Pointer, faceSize, 0, 0, 0, width, height, 1, (uint)level, NegativeYArrayLayer);
+                    gd.UpdateTexture(cubemapTexture, (IntPtr)positiveZPin.Pointer, faceSize, 0, 0, 0, width, height, 1, (uint)level, PositiveZArrayLayer);
+                    gd.UpdateTexture(cubemapTexture, (IntPtr)negativeZPin.Pointer, faceSize, 0, 0, 0, width, height, 1, (uint)level, NegativeZArrayLayer);
                 }
             }
             return cubemapTexture;

--- a/src/Veldrid.ImageSharp/ImageSharpTexture.cs
+++ b/src/Veldrid.ImageSharp/ImageSharpTexture.cs
@@ -1,10 +1,9 @@
 ﻿using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using System;
+using System.Buffers;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Veldrid.ImageSharp
 {
@@ -80,24 +79,24 @@ namespace Veldrid.ImageSharp
             for (uint level = 0; level < MipLevels; level++)
             {
                 Image<Rgba32> image = Images[level];
-                if (!image.TryGetSinglePixelSpan(out Span<Rgba32> pixelSpan))
+                if (!image.DangerousTryGetSinglePixelMemory(out Memory<Rgba32> pixelMemory))
                 {
-                    throw new VeldridException("Unable to get image pixelspan.");
+                    throw new VeldridException("Unable to get image pixelspan. Make sure to initialize MemoryAllocator.Default!");
                 }
-                fixed (void* pin = &MemoryMarshal.GetReference(pixelSpan))
+                using(MemoryHandle pin = pixelMemory.Pin())
                 {
                     MappedResource map = gd.Map(staging, MapMode.Write, level);
                     uint rowWidth = (uint)(image.Width * 4);
                     if (rowWidth == map.RowPitch)
                     {
-                        Unsafe.CopyBlock(map.Data.ToPointer(), pin, (uint)(image.Width * image.Height * 4));
+                        Unsafe.CopyBlock(map.Data.ToPointer(), pin.Pointer, (uint)(image.Width * image.Height * 4));
                     }
                     else
                     {
                         for (uint y = 0; y < image.Height; y++)
                         {
                             byte* dstStart = (byte*)map.Data.ToPointer() + y * map.RowPitch;
-                            byte* srcStart = (byte*)pin + y * rowWidth;
+                            byte* srcStart = (byte*)pin.Pointer + y * rowWidth;
                             Unsafe.CopyBlock(dstStart, srcStart, rowWidth);
                         }
                     }
@@ -126,15 +125,15 @@ namespace Veldrid.ImageSharp
             for (int level = 0; level < MipLevels; level++)
             {
                 Image<Rgba32> image = Images[level];
-                if (!image.TryGetSinglePixelSpan(out Span<Rgba32> pixelSpan))
+                if (!image.DangerousTryGetSinglePixelMemory(out Memory<Rgba32> pixelMemory))
                 {
-                    throw new VeldridException("Unable to get image pixelspan.");
+                    throw new VeldridException("Unable to get image pixelspan. Make sure to initialize MemoryAllocator.Default!");
                 }
-                fixed (void* pin = &MemoryMarshal.GetReference(pixelSpan))
+                using (MemoryHandle pin = pixelMemory.Pin())
                 {
                     gd.UpdateTexture(
                         tex,
-                        (IntPtr)pin,
+                        (IntPtr)pin.Pointer,
                         (uint)(PixelSizeInBytes * image.Width * image.Height),
                         0,
                         0,

--- a/src/Veldrid.ImageSharp/Veldrid.ImageSharp.csproj
+++ b/src/Veldrid.ImageSharp/Veldrid.ImageSharp.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Veldrid\Veldrid.csproj" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The method `TryGetSinglePixelSpan` has been replaced with pixel processors to ensure memory safety while increasing perf.
https://github.com/SixLabors/ImageSharp/issues/1739

`DangerousTryGetSinglePixelMemory` is an alternative to pixel processors recommended for interop functionality.

I did not test the code yet and will add some if I find the time and ability.