### PR TITLE
Use constant stackalloc in SetObjectLabel

### DIFF
--- a/src/Veldrid/OpenGL/OpenGLUtil.cs
+++ b/src/Veldrid/OpenGL/OpenGLUtil.cs
@@ -43,11 +43,15 @@ namespace Veldrid.OpenGL
                     byteCount = Encoding.UTF8.GetByteCount(name);
                 }
 
-                byte* utf8Ptr = stackalloc byte[byteCount];
+                Span<byte> utf8bytes = stackalloc byte[128];
+                if(byteCount + 1 > 128) utf8bytes = new byte[byteCount + 1];
+
                 fixed (char* namePtr = name)
+                fixed (byte* utf8bytePtr = utf8bytes)
                 {
-                    Encoding.UTF8.GetBytes(namePtr, name.Length, utf8Ptr, byteCount);
-                    glObjectLabel(identifier, target, (uint)byteCount, utf8Ptr);
+                    int written = Encoding.UTF8.GetBytes(namePtr, name.Length, utf8bytePtr, byteCount);
+                    utf8bytePtr[written] = 0;
+                    glObjectLabel(identifier, target, (uint)byteCount, utf8bytePtr);
                     CheckLastError();
                 }
             }

--- a/src/Veldrid/OpenGL/OpenGLUtil.cs
+++ b/src/Veldrid/OpenGL/OpenGLUtil.cs
@@ -1,3 +1,4 @@
+using System;
 ﻿using System.Diagnostics;
 using System.Text;
 using Veldrid.OpenGLBinding;


### PR DESCRIPTION
Fix possible StackOverflowException (in case of a crazy opengl driver)
Fix `""` (empty) label causing crash (because `stackalloc byte[0]` returns `(byte*) null`
Improve performance by using a constant-sized stackalloc
Use null-terminated string