### PR TITLE
Fix native crash when running Metal on Apple Silicon

### DIFF
--- a/src/Veldrid.MetalBindings/NSView.cs
+++ b/src/Veldrid.MetalBindings/NSView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using static Veldrid.MetalBindings.ObjectiveCRuntime;
 
 namespace Veldrid.MetalBindings
@@ -22,7 +23,12 @@ namespace Veldrid.MetalBindings
 
         public CGRect frame
         {
-            get => objc_msgSend_stret<CGRect>(NativePtr, "frame");
+            get
+            {
+                return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                    ? CGRect_objc_msgSend(NativePtr, "frame")
+                    : objc_msgSend_stret<CGRect>(NativePtr, "frame");
+            }
         }
     }
 }


### PR DESCRIPTION
- Split from #404 
- Mostly (resolves) #402 

In efforts to keep things going (since it's been a while for that PR and most of the changes have already been merged recently, e.g. .NET 6 bump), I've split this specific change out just to get Metal working on Apple Silicon.

Have tested that this works properly for the project I'm using Veldrid on.