### PR TITLE
Add validation of GL structured buffer names, fix warnings due to stackalloc inside loops.

### DIFF
--- a/src/Veldrid.OpenGLBindings/Enums.cs
+++ b/src/Veldrid.OpenGLBindings/Enums.cs
@@ -1802,6 +1802,14 @@ namespace Veldrid.OpenGLBinding
         TransformFeedbackVarying = ((int)0x92F4),
     }
 
+    public enum ProgramInterfaceParameterName : int
+    {
+        ActiveResources = 0x92F5,
+        MaxNameLength = 0x92F6,
+        MaxNumActiveVariables = 0x92F7,
+        MaxNumCompatibleSubroutines = 0x92F8,
+    }
+
     public enum TextureAccess : int
     {
         ReadOnly = ((int)0x88B8),

--- a/src/Veldrid.OpenGLBindings/OpenGLNative.cs
+++ b/src/Veldrid.OpenGLBindings/OpenGLNative.cs
@@ -919,10 +919,25 @@ namespace Veldrid.OpenGLBinding
             => p_glDispatchCompute(num_groups_x, num_groups_y, num_groups_z);
 
         [UnmanagedFunctionPointer(CallConv)]
+        private delegate uint glGetProgramInterfaceiv_t(uint program, ProgramInterface programInterface, ProgramInterfaceParameterName pname, int* @params);
+        private static glGetProgramInterfaceiv_t p_glGetProgramInterfaceiv;
+        public static uint glGetProgramInterfaceiv(uint program, ProgramInterface programInterface, ProgramInterfaceParameterName pname, int* @params)
+            => p_glGetProgramInterfaceiv(program, programInterface, pname, @params);
+
+        [UnmanagedFunctionPointer(CallConv)]
         private delegate uint glGetProgramResourceIndex_t(uint program, ProgramInterface programInterface, byte* name);
         private static glGetProgramResourceIndex_t p_glGetProgramResourceIndex;
         public static uint glGetProgramResourceIndex(uint program, ProgramInterface programInterface, byte* name)
             => p_glGetProgramResourceIndex(program, programInterface, name);
+
+        [UnmanagedFunctionPointer(CallConv)]
+        private delegate uint glGetProgramResourceName_t(uint program, ProgramInterface programInterface, uint index, uint bufSize, uint* length, byte* name);
+        private static glGetProgramResourceName_t p_glGetProgramResourceName;
+        public static uint glGetProgramResourceName(uint program, ProgramInterface programInterface, uint index, uint bufSize, uint* length, byte* name)
+            => p_glGetProgramResourceName(program, programInterface, index, bufSize, length, name);
+
+        // LoadFunction("glGetProgramInterface", out p_glGetProgramInterface);
+        // LoadFunction("glGetProgramResourceName", out p_glGetProgramResourceName);
 
         [UnmanagedFunctionPointer(CallConv)]
         private delegate void glShaderStorageBlockBinding_t(uint program, uint storageBlockIndex, uint storageBlockBinding);
@@ -1815,6 +1830,9 @@ namespace Veldrid.OpenGLBinding
             LoadFunction("glLinkProgram", out p_glLinkProgram);
             LoadFunction("glGetProgramiv", out p_glGetProgramiv);
             LoadFunction("glGetProgramInfoLog", out p_glGetProgramInfoLog);
+            LoadFunction("glGetProgramInterfaceiv", out p_glGetProgramInterfaceiv);
+            LoadFunction("glGetProgramResourceIndex", out p_glGetProgramResourceIndex);
+            LoadFunction("glGetProgramResourceName", out p_glGetProgramResourceName);
             LoadFunction("glUniformBlockBinding", out p_glUniformBlockBinding);
             LoadFunction("glDeleteProgram", out p_glDeleteProgram);
             LoadFunction("glUniform1i", out p_glUniform1i);
@@ -1844,7 +1862,6 @@ namespace Veldrid.OpenGLBinding
             LoadFunction("glBlitFramebuffer", out p_glBlitFramebuffer);
             LoadFunction("glFramebufferTextureLayer", out p_glFramebufferTextureLayer);
             LoadFunction("glDispatchCompute", out p_glDispatchCompute);
-            LoadFunction("glGetProgramResourceIndex", out p_glGetProgramResourceIndex);
             LoadFunction("glShaderStorageBlockBinding", out p_glShaderStorageBlockBinding);
             LoadFunction("glDrawElementsIndirect", out p_glDrawElementsIndirect);
             LoadFunction("glMultiDrawElementsIndirect", out p_glMultiDrawElementsIndirect);

--- a/src/Veldrid.OpenGLBindings/OpenGLNative.cs
+++ b/src/Veldrid.OpenGLBindings/OpenGLNative.cs
@@ -936,9 +936,6 @@ namespace Veldrid.OpenGLBinding
         public static uint glGetProgramResourceName(uint program, ProgramInterface programInterface, uint index, uint bufSize, uint* length, byte* name)
             => p_glGetProgramResourceName(program, programInterface, index, bufSize, length, name);
 
-        // LoadFunction("glGetProgramInterface", out p_glGetProgramInterface);
-        // LoadFunction("glGetProgramResourceName", out p_glGetProgramResourceName);
-
         [UnmanagedFunctionPointer(CallConv)]
         private delegate void glShaderStorageBlockBinding_t(uint program, uint storageBlockIndex, uint storageBlockBinding);
         private static glShaderStorageBlockBinding_t p_glShaderStorageBlockBinding;

--- a/src/Veldrid/OpenGL/OpenGLPipeline.cs
+++ b/src/Veldrid/OpenGL/OpenGLPipeline.cs
@@ -138,7 +138,9 @@ namespace Veldrid.OpenGL
                 {
                     int location = GetAttribLocation(layoutDesc.Elements[i].Name);
                     if (location == -1)
+                    {
                         throw new VeldridException("There was no attribute variable with the name " + layoutDesc.Elements[i].Name);
+                    }
 
                     slot += 1;
                 }
@@ -298,7 +300,9 @@ namespace Veldrid.OpenGL
                     glGetActiveUniformBlockName(_program, uniformBufferIndex, bufferNameByteCount, &actualLength, bufferNamePtr);
 
                     if (glGetError() != 0)
+                    {
                         break;
+                    }
 
                     string name = Encoding.UTF8.GetString(bufferNamePtr, (int)actualLength);
                     names.Add(name);
@@ -326,8 +330,10 @@ namespace Veldrid.OpenGL
             CheckLastError();
 
 #if DEBUG && GL_VALIDATE_SHADER_RESOURCE_NAMES
-            if(location == -1)
+            if (location == -1)
+            {
                 ReportInvalidUniformName(resourceName);
+            }
 #endif
             return location;
         }
@@ -348,7 +354,9 @@ namespace Veldrid.OpenGL
             CheckLastError();
 #if DEBUG && GL_VALIDATE_SHADER_RESOURCE_NAMES
             if (binding == GL_INVALID_INDEX)
+            {
                 ReportInvalidResourceName(resourceName, resourceType);
+            }
 #endif
             return binding;
         }
@@ -370,7 +378,9 @@ namespace Veldrid.OpenGL
                     &actualLength, &size, &type, resourceNamePtr);
 
                 if (glGetError() != 0)
+                {
                     break;
+                }
 
                 string name = Encoding.UTF8.GetString(resourceNamePtr, (int)actualLength);
                 names.Add(name);
@@ -382,6 +392,12 @@ namespace Veldrid.OpenGL
 
         void ReportInvalidResourceName(string resourceName, ProgramInterface resourceType)
         {
+            // glGetProgramInterfaceiv and glGetProgramResourceName are only available in 4.3+
+            if (_gd.ApiVersion.Major < 4 || (_gd.ApiVersion.Major == 4 && _gd.ApiVersion.Minor < 3))
+            {
+                return;
+            }
+
             int maxLength = 0;
             int resourceCount = 0;
             glGetProgramInterfaceiv(_program, resourceType, ProgramInterfaceParameterName.MaxNameLength, &maxLength);
@@ -395,7 +411,9 @@ namespace Veldrid.OpenGL
                 glGetProgramResourceName(_program, resourceType, resourceIndex, (uint)maxLength, &actualLength, resourceNamePtr);
 
                 if (glGetError() != 0)
+                {
                     break;
+                }
 
                 string name = Encoding.UTF8.GetString(resourceNamePtr, (int)actualLength);
                 names.Add(name);

--- a/src/Veldrid/OpenGL/OpenGLPipeline.cs
+++ b/src/Veldrid/OpenGL/OpenGLPipeline.cs
@@ -122,19 +122,7 @@ namespace Veldrid.OpenGL
             {
                 for (int i = 0; i < layoutDesc.Elements.Length; i++)
                 {
-                    string elementName = layoutDesc.Elements[i].Name;
-                    int byteCount = Encoding.UTF8.GetByteCount(elementName) + 1;
-                    byte* elementNamePtr = stackalloc byte[byteCount];
-                    fixed (char* charPtr = elementName)
-                    {
-                        int bytesWritten = Encoding.UTF8.GetBytes(charPtr, elementName.Length, elementNamePtr, byteCount);
-                        Debug.Assert(bytesWritten == byteCount - 1);
-                    }
-                    elementNamePtr[byteCount - 1] = 0; // Add null terminator.
-
-                    glBindAttribLocation(_program, slot, elementNamePtr);
-                    CheckLastError();
-
+                    BindAttribLocation(slot, layoutDesc.Elements[i].Name);
                     slot += 1;
                 }
             }
@@ -148,21 +136,10 @@ namespace Veldrid.OpenGL
             {
                 for (int i = 0; i < layoutDesc.Elements.Length; i++)
                 {
-                    string elementName = layoutDesc.Elements[i].Name;
-                    int byteCount = Encoding.UTF8.GetByteCount(elementName) + 1;
-                    byte* elementNamePtr = stackalloc byte[byteCount];
-                    fixed (char* charPtr = elementName)
-                    {
-                        int bytesWritten = Encoding.UTF8.GetBytes(charPtr, elementName.Length, elementNamePtr, byteCount);
-                        Debug.Assert(bytesWritten == byteCount - 1);
-                    }
-                    elementNamePtr[byteCount - 1] = 0; // Add null terminator.
-
-                    int location = glGetAttribLocation(_program, elementNamePtr);
+                    int location = GetAttribLocation(layoutDesc.Elements[i].Name);
                     if (location == -1)
-                    {
                         throw new VeldridException("There was no attribute variable with the name " + layoutDesc.Elements[i].Name);
-                    }
+
                     slot += 1;
                 }
             }
@@ -182,6 +159,36 @@ namespace Veldrid.OpenGL
             }
 
             ProcessResourceSetLayouts(ResourceLayouts);
+        }
+
+        int GetAttribLocation(string elementName)
+        {
+            int byteCount = Encoding.UTF8.GetByteCount(elementName) + 1;
+            byte* elementNamePtr = stackalloc byte[byteCount];
+            fixed (char* charPtr = elementName)
+            {
+                int bytesWritten = Encoding.UTF8.GetBytes(charPtr, elementName.Length, elementNamePtr, byteCount);
+                Debug.Assert(bytesWritten == byteCount - 1);
+            }
+            elementNamePtr[byteCount - 1] = 0; // Add null terminator.
+
+            int location = glGetAttribLocation(_program, elementNamePtr);
+            return location;
+        }
+
+        void BindAttribLocation(uint slot, string elementName)
+        {
+            int byteCount = Encoding.UTF8.GetByteCount(elementName) + 1;
+            byte* elementNamePtr = stackalloc byte[byteCount];
+            fixed (char* charPtr = elementName)
+            {
+                int bytesWritten = Encoding.UTF8.GetBytes(charPtr, elementName.Length, elementNamePtr, byteCount);
+                Debug.Assert(bytesWritten == byteCount - 1);
+            }
+            elementNamePtr[byteCount - 1] = 0; // Add null terminator.
+
+            glBindAttribLocation(_program, slot, elementNamePtr);
+            CheckLastError();
         }
 
         private void ProcessResourceSetLayouts(ResourceLayout[] layouts)
@@ -209,18 +216,7 @@ namespace Veldrid.OpenGL
                     ResourceLayoutElementDescription resource = resources[i];
                     if (resource.Kind == ResourceKind.UniformBuffer)
                     {
-                        string resourceName = resource.Name;
-                        int byteCount = Encoding.UTF8.GetByteCount(resourceName) + 1;
-                        byte* resourceNamePtr = stackalloc byte[byteCount];
-                        fixed (char* charPtr = resourceName)
-                        {
-                            int bytesWritten = Encoding.UTF8.GetBytes(charPtr, resourceName.Length, resourceNamePtr, byteCount);
-                            Debug.Assert(bytesWritten == byteCount - 1);
-                        }
-                        resourceNamePtr[byteCount - 1] = 0; // Add null terminator.
-
-                        uint blockIndex = glGetUniformBlockIndex(_program, resourceNamePtr);
-                        CheckLastError();
+                        uint blockIndex = GetUniformBlockIndex(resource.Name);
                         if (blockIndex != GL_INVALID_INDEX)
                         {
                             int blockSize;
@@ -228,47 +224,10 @@ namespace Veldrid.OpenGL
                             CheckLastError();
                             uniformBindings[i] = new OpenGLUniformBinding(_program, blockIndex, (uint)blockSize);
                         }
-#if DEBUG && GL_VALIDATE_SHADER_RESOURCE_NAMES
-                        else
-                        {
-                            uint uniformBufferIndex = 0;
-                            uint bufferNameByteCount = 64;
-                            byte* bufferNamePtr = stackalloc byte[(int)bufferNameByteCount];
-                            var names = new List<string>();
-                            while (true)
-                            {
-                                uint actualLength;
-                                glGetActiveUniformBlockName(_program, uniformBufferIndex, bufferNameByteCount, &actualLength, bufferNamePtr);
-
-                                if (glGetError() != 0)
-                                    break;
-
-                                string name = Encoding.UTF8.GetString(bufferNamePtr, (int)actualLength);
-                                names.Add(name);
-                                uniformBufferIndex++;
-                            }
-
-                            throw new VeldridException($"Unable to bind uniform buffer \"{resourceName}\" by name. Valid names for this pipeline are: {string.Join(", ", names)}");
-                        }
-#endif
                     }
                     else if (resource.Kind == ResourceKind.TextureReadOnly)
                     {
-                        string resourceName = resource.Name;
-                        int byteCount = Encoding.UTF8.GetByteCount(resourceName) + 1;
-                        byte* resourceNamePtr = stackalloc byte[byteCount];
-                        fixed (char* charPtr = resourceName)
-                        {
-                            int bytesWritten = Encoding.UTF8.GetBytes(charPtr, resourceName.Length, resourceNamePtr, byteCount);
-                            Debug.Assert(bytesWritten == byteCount - 1);
-                        }
-                        resourceNamePtr[byteCount - 1] = 0; // Add null terminator.
-                        int location = glGetUniformLocation(_program, resourceNamePtr);
-                        CheckLastError();
-#if DEBUG && GL_VALIDATE_SHADER_RESOURCE_NAMES
-                        if(location == -1)
-                            ReportInvalidResourceName(resourceName);
-#endif
+                        int location = GetUniformLocation(resource.Name);
                         relativeTextureIndex += 1;
                         textureBindings[i] = new OpenGLTextureBindingSlotInfo() { RelativeIndex = relativeTextureIndex, UniformLocation = location };
                         lastTextureLocation = location;
@@ -276,21 +235,7 @@ namespace Veldrid.OpenGL
                     }
                     else if (resource.Kind == ResourceKind.TextureReadWrite)
                     {
-                        string resourceName = resource.Name;
-                        int byteCount = Encoding.UTF8.GetByteCount(resourceName) + 1;
-                        byte* resourceNamePtr = stackalloc byte[byteCount];
-                        fixed (char* charPtr = resourceName)
-                        {
-                            int bytesWritten = Encoding.UTF8.GetBytes(charPtr, resourceName.Length, resourceNamePtr, byteCount);
-                            Debug.Assert(bytesWritten == byteCount - 1);
-                        }
-                        resourceNamePtr[byteCount - 1] = 0; // Add null terminator.
-                        int location = glGetUniformLocation(_program, resourceNamePtr);
-                        CheckLastError();
-#if DEBUG && GL_VALIDATE_SHADER_RESOURCE_NAMES
-                        if(location == -1)
-                            ReportInvalidResourceName(resourceName);
-#endif
+                        int location = GetUniformLocation(resource.Name);
                         relativeImageIndex += 1;
                         textureBindings[i] = new OpenGLTextureBindingSlotInfo() { RelativeIndex = relativeImageIndex, UniformLocation = location };
                     }
@@ -300,20 +245,7 @@ namespace Veldrid.OpenGL
                         uint storageBlockBinding;
                         if (_gd.BackendType == GraphicsBackend.OpenGL)
                         {
-                            string resourceName = resource.Name;
-                            int byteCount = Encoding.UTF8.GetByteCount(resourceName) + 1;
-                            byte* resourceNamePtr = stackalloc byte[byteCount];
-                            fixed (char* charPtr = resourceName)
-                            {
-                                int bytesWritten = Encoding.UTF8.GetBytes(charPtr, resourceName.Length, resourceNamePtr, byteCount);
-                                Debug.Assert(bytesWritten == byteCount - 1);
-                            }
-                            resourceNamePtr[byteCount - 1] = 0; // Add null terminator.
-                            storageBlockBinding = glGetProgramResourceIndex(
-                                _program,
-                                ProgramInterface.ShaderStorageBlock,
-                                resourceNamePtr);
-                            CheckLastError();
+                            storageBlockBinding = GetProgramResourceIndex(resource.Name, ProgramInterface.ShaderStorageBlock);
                         }
                         else
                         {
@@ -340,8 +272,89 @@ namespace Veldrid.OpenGL
             }
         }
 
+        uint GetUniformBlockIndex(string resourceName)
+        {
+            int byteCount = Encoding.UTF8.GetByteCount(resourceName) + 1;
+            byte* resourceNamePtr = stackalloc byte[byteCount];
+            fixed (char* charPtr = resourceName)
+            {
+                int bytesWritten = Encoding.UTF8.GetBytes(charPtr, resourceName.Length, resourceNamePtr, byteCount);
+                Debug.Assert(bytesWritten == byteCount - 1);
+            }
+            resourceNamePtr[byteCount - 1] = 0; // Add null terminator.
+
+            uint blockIndex = glGetUniformBlockIndex(_program, resourceNamePtr);
+            CheckLastError();
 #if DEBUG && GL_VALIDATE_SHADER_RESOURCE_NAMES
-        void ReportInvalidResourceName(string resourceName)
+            if (blockIndex == GL_INVALID_INDEX)
+            {
+                uint uniformBufferIndex = 0;
+                uint bufferNameByteCount = 64;
+                byte* bufferNamePtr = stackalloc byte[(int)bufferNameByteCount];
+                var names = new List<string>();
+                while (true)
+                {
+                    uint actualLength;
+                    glGetActiveUniformBlockName(_program, uniformBufferIndex, bufferNameByteCount, &actualLength, bufferNamePtr);
+
+                    if (glGetError() != 0)
+                        break;
+
+                    string name = Encoding.UTF8.GetString(bufferNamePtr, (int)actualLength);
+                    names.Add(name);
+                    uniformBufferIndex++;
+                }
+
+                throw new VeldridException($"Unable to bind uniform buffer \"{resourceName}\" by name. Valid names for this pipeline are: {string.Join(", ", names)}");
+            }
+#endif
+            return blockIndex;
+        }
+
+        int GetUniformLocation(string resourceName)
+        {
+            int byteCount = Encoding.UTF8.GetByteCount(resourceName) + 1;
+            byte* resourceNamePtr = stackalloc byte[byteCount];
+            fixed (char* charPtr = resourceName)
+            {
+                int bytesWritten = Encoding.UTF8.GetBytes(charPtr, resourceName.Length, resourceNamePtr, byteCount);
+                Debug.Assert(bytesWritten == byteCount - 1);
+            }
+            resourceNamePtr[byteCount - 1] = 0; // Add null terminator.
+
+            int location = glGetUniformLocation(_program, resourceNamePtr);
+            CheckLastError();
+
+#if DEBUG && GL_VALIDATE_SHADER_RESOURCE_NAMES
+            if(location == -1)
+                ReportInvalidUniformName(resourceName);
+#endif
+            return location;
+        }
+
+        uint GetProgramResourceIndex(string resourceName, ProgramInterface resourceType)
+        {
+            int byteCount = Encoding.UTF8.GetByteCount(resourceName) + 1;
+
+            byte* resourceNamePtr = stackalloc byte[byteCount];
+            fixed (char* charPtr = resourceName)
+            {
+                int bytesWritten = Encoding.UTF8.GetBytes(charPtr, resourceName.Length, resourceNamePtr, byteCount);
+                Debug.Assert(bytesWritten == byteCount - 1);
+            }
+            resourceNamePtr[byteCount - 1] = 0; // Add null terminator.
+
+            uint binding = glGetProgramResourceIndex(_program, resourceType, resourceNamePtr);
+            CheckLastError();
+#if DEBUG && GL_VALIDATE_SHADER_RESOURCE_NAMES
+            if (binding == GL_INVALID_INDEX)
+                ReportInvalidResourceName(resourceName, resourceType);
+#endif
+            return binding;
+        }
+
+#if DEBUG && GL_VALIDATE_SHADER_RESOURCE_NAMES
+        void ReportInvalidUniformName(string uniformName)
         {
             uint uniformIndex = 0;
             uint resourceNameByteCount = 64;
@@ -364,7 +377,31 @@ namespace Veldrid.OpenGL
                 uniformIndex++;
             }
 
-            throw new VeldridException($"Unable to bind uniform \"{resourceName}\" by name. Valid names for this pipeline are: {string.Join(", ", names)}");
+            throw new VeldridException($"Unable to bind uniform \"{uniformName}\" by name. Valid names for this pipeline are: {string.Join(", ", names)}");
+        }
+
+        void ReportInvalidResourceName(string resourceName, ProgramInterface resourceType)
+        {
+            int maxLength = 0;
+            int resourceCount = 0;
+            glGetProgramInterfaceiv(_program, resourceType, ProgramInterfaceParameterName.MaxNameLength, &maxLength);
+            glGetProgramInterfaceiv(_program, resourceType, ProgramInterfaceParameterName.ActiveResources, &resourceCount);
+            byte* resourceNamePtr = stackalloc byte[maxLength];
+
+            var names = new List<string>();
+            for (uint resourceIndex = 0; resourceIndex < resourceCount; resourceIndex++)
+            {
+                uint actualLength;
+                glGetProgramResourceName(_program, resourceType, resourceIndex, (uint)maxLength, &actualLength, resourceNamePtr);
+
+                if (glGetError() != 0)
+                    break;
+
+                string name = Encoding.UTF8.GetString(resourceNamePtr, (int)actualLength);
+                names.Add(name);
+            }
+
+            throw new VeldridException($"Unable to bind {resourceType} \"{resourceName}\" by name. Valid names for this pipeline are: {string.Join(", ", names)}");
         }
 #endif
 


### PR DESCRIPTION
Fixed a few instances of CA2014 ("Do not use stackalloc in loops"), and also added better exception messages after trying to use an invalid structured buffer name when compiling with GL_VALIDATE_SHADER_RESOURCE_NAMES.