### PR TITLE
Added an exception throw when a ResourceLayout slot is null

### DIFF
--- a/src/Veldrid/CommandList.cs
+++ b/src/Veldrid/CommandList.cs
@@ -222,7 +222,9 @@ namespace Veldrid
                     $"Failed to bind ResourceSet to slot {slot}. The active graphics Pipeline only contains {layoutsCount} ResourceLayouts.");
             }
 
-            ResourceLayout layout = _graphicsPipeline.ResourceLayouts[slot];
+            ResourceLayout layout = _graphicsPipeline.ResourceLayouts[slot]
+                ?? throw new VeldridException($"There is no ResourceLayout at slot {slot} in the active graphics Pipeline");
+
             int pipelineLength = layout.Description.Elements.Length;
             ResourceLayoutDescription layoutDesc = rs.Layout.Description;
             int setLength = layoutDesc.Elements.Length;


### PR DESCRIPTION
When a ResourceLayout array was bound to a Pipeline and, by accident, one of its members remained `null`, the CommandList would throw a `NullReferenceException` that described very little of the problem and therefore was hard to figure out and debug.

This pull request fixes the issue by adding a check through a null-coalescing operator