### PR TITLE
Updated CreateVulkanGraphicsDevice helper to use SwapchainSrgbFormat setting

### DIFF
--- a/src/Veldrid.StartupUtilities/VeldridStartup.cs
+++ b/src/Veldrid.StartupUtilities/VeldridStartup.cs
@@ -206,7 +206,7 @@ namespace Veldrid.StartupUtilities
 
 #if !EXCLUDE_VULKAN_BACKEND
         public static unsafe GraphicsDevice CreateVulkanGraphicsDevice(GraphicsDeviceOptions options, Sdl2Window window)
-            => CreateVulkanGraphicsDevice(options, window, false);
+            => CreateVulkanGraphicsDevice(options, window, options.SwapchainSrgbFormat);
         public static unsafe GraphicsDevice CreateVulkanGraphicsDevice(
             GraphicsDeviceOptions options,
             Sdl2Window window,


### PR DESCRIPTION
The CreateVulkanGraphicsDevice helper was passing a hardcoded false and ignoring the SwapchainSrgbFormat setting from the options argument.