### PR TITLE
Update to Vortice 2.1.32 to fix crash on M360 Intel Integrated Graphics

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <VeldridSpirvVersion>1.0.14</VeldridSpirvVersion>
     <NativeLibraryLoaderVersion>1.0.12</NativeLibraryLoaderVersion>
-    <VorticeWindowsVersion>2.1.0</VorticeWindowsVersion>
+    <VorticeWindowsVersion>2.1.32</VorticeWindowsVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Veldrid/D3D11/D3D11Buffer.cs
+++ b/src/Veldrid/D3D11/D3D11Buffer.cs
@@ -44,28 +44,28 @@ namespace Veldrid.D3D11
             {
                 if (rawBuffer)
                 {
-                    bd.OptionFlags = ResourceOptionFlags.BufferAllowRawViews;
+                    bd.MiscFlags = ResourceOptionFlags.BufferAllowRawViews;
                 }
                 else
                 {
-                    bd.OptionFlags = ResourceOptionFlags.BufferStructured;
+                    bd.MiscFlags = ResourceOptionFlags.BufferStructured;
                     bd.StructureByteStride = (int)structureByteStride;
                 }
             }
             if ((usage & BufferUsage.IndirectBuffer) == BufferUsage.IndirectBuffer)
             {
-                bd.OptionFlags = ResourceOptionFlags.DrawIndirectArguments;
+                bd.MiscFlags = ResourceOptionFlags.DrawIndirectArguments;
             }
 
             if ((usage & BufferUsage.Dynamic) == BufferUsage.Dynamic)
             {
                 bd.Usage = ResourceUsage.Dynamic;
-                bd.CpuAccessFlags = CpuAccessFlags.Write;
+                bd.CPUAccessFlags = CpuAccessFlags.Write;
             }
             else if ((usage & BufferUsage.Staging) == BufferUsage.Staging)
             {
                 bd.Usage = ResourceUsage.Staging;
-                bd.CpuAccessFlags = CpuAccessFlags.Read | CpuAccessFlags.Write;
+                bd.CPUAccessFlags = CpuAccessFlags.Read | CpuAccessFlags.Write;
             }
 
             _buffer = device.CreateBuffer(bd);

--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -358,13 +358,14 @@ namespace Veldrid.D3D11
                         lock (_immediateContextLock)
                         {
                             Util.GetMipLevelAndArrayLayer(texture, subresource, out uint mipLevel, out uint arrayLayer);
-                            MappedSubresource msr = _immediateContext.Map(
+                            _immediateContext.Map(
                                 texture.DeviceTexture,
                                 (int)mipLevel,
                                 (int)arrayLayer,
                                 D3D11Formats.VdToD3D11MapMode(false, mode),
                                 Vortice.Direct3D11.MapFlags.None,
-                                out int mipSize);
+                                out int mipSize,
+                                out MappedSubresource msr);
 
                             info.MappedResource = new MappedResource(
                                 resource,

--- a/src/Veldrid/D3D11/D3D11Shader.cs
+++ b/src/Veldrid/D3D11/D3D11Shader.cs
@@ -88,10 +88,10 @@ namespace Veldrid.D3D11
 
             if (result == null)
             {
-                throw new VeldridException($"Failed to compile HLSL code: {Encoding.ASCII.GetString(error.GetBytes())}");
+                throw new VeldridException($"Failed to compile HLSL code: {Encoding.ASCII.GetString(error.AsBytes())}");
             }
 
-            return result.GetBytes();
+            return result.AsBytes();
         }
 
         public override string Name

--- a/src/Veldrid/D3D11/D3D11Texture.cs
+++ b/src/Veldrid/D3D11/D3D11Texture.cs
@@ -99,9 +99,9 @@ namespace Veldrid.D3D11
                     ArraySize = arraySize,
                     Format = TypelessDxgiFormat,
                     BindFlags = bindFlags,
-                    CpuAccessFlags = cpuFlags,
+                    CPUAccessFlags = cpuFlags,
                     Usage = resourceUsage,
-                    OptionFlags = optionFlags,
+                    MiscFlags= optionFlags,
                 };
 
                 DeviceTexture = device.CreateTexture1D(desc1D);
@@ -116,10 +116,10 @@ namespace Veldrid.D3D11
                     ArraySize = arraySize,
                     Format = TypelessDxgiFormat,
                     BindFlags = bindFlags,
-                    CpuAccessFlags = cpuFlags,
+                    CPUAccessFlags = cpuFlags,
                     Usage = resourceUsage,
                     SampleDescription = new Vortice.DXGI.SampleDescription((int)FormatHelpers.GetSampleCountUInt32(SampleCount), 0),
-                    OptionFlags = optionFlags,
+                    MiscFlags = optionFlags,
                 };
 
                 DeviceTexture = device.CreateTexture2D(deviceDescription);
@@ -135,9 +135,9 @@ namespace Veldrid.D3D11
                     MipLevels = (int)description.MipLevels,
                     Format = TypelessDxgiFormat,
                     BindFlags = bindFlags,
-                    CpuAccessFlags = cpuFlags,
+                    CPUAccessFlags = cpuFlags,
                     Usage = resourceUsage,
-                    OptionFlags = optionFlags,
+                    MiscFlags = optionFlags,
                 };
 
                 DeviceTexture = device.CreateTexture3D(desc3D);
@@ -158,8 +158,8 @@ namespace Veldrid.D3D11
             Type = type;
             Usage = D3D11Formats.GetVdUsage(
                 existingTexture.Description.BindFlags,
-                existingTexture.Description.CpuAccessFlags,
-                existingTexture.Description.OptionFlags);
+                existingTexture.Description.CPUAccessFlags,
+                existingTexture.Description.MiscFlags);
 
             DxgiFormat = D3D11Formats.ToDxgiFormat(
                 format,

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Eric, 

This pull request is needed to fix a crash that is currently occurring on Intel Integrated Graphics (M360 specifically).   The crash occurs due to Vortice 2.1.0 incorrectly setting a uniform buffer pointer to IntPtr.Zero in VSUnsetConstantBuffer (ID3D11DeviceContext.cs).   Recent changes have corrected the issue.