### PR TITLE
ImGui: Fix negative scissor rect offsets

### DIFF
--- a/src/Veldrid.ImGui/ImGuiRenderer.cs
+++ b/src/Veldrid.ImGui/ImGuiRenderer.cs
@@ -708,12 +708,14 @@ namespace Veldrid
                             }
                         }
 
+                        float clipRectX = Math.Max(0, pcmd.ClipRect.X); // Vulkan validation requires positive scissor offsets
+                        float clipRectY = Math.Max(0, pcmd.ClipRect.Y);
                         cl.SetScissorRect(
                             0,
-                            (uint)pcmd.ClipRect.X,
-                            (uint)pcmd.ClipRect.Y,
-                            (uint)(pcmd.ClipRect.Z - pcmd.ClipRect.X),
-                            (uint)(pcmd.ClipRect.W - pcmd.ClipRect.Y));
+                            (uint)clipRectX,
+                            (uint)clipRectY,
+                            (uint)(pcmd.ClipRect.Z - clipRectX),
+                            (uint)(pcmd.ClipRect.W - clipRectY));
 
                         cl.DrawIndexed(pcmd.ElemCount, 1, pcmd.IdxOffset + (uint)idx_offset, (int)(pcmd.VtxOffset + vtx_offset), 0);
                     }


### PR DESCRIPTION
With Vulkan Validation layers enabled, opening any ImGui modal causes a validation error due to negative scissor offsets ([VUID-vkCmdSetScissor-x-00595](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCmdSetScissor.html#VUID-vkCmdSetScissor-x-00595)). According to the other rules it is fine to overshoot on width and height, so I kept the fix minimal.

The validation error can be reproduced in NeoDemo by using the ImGui Demo and opening a sample modal.