### PR TITLE
Update Vortice.Windows to latest stable version.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <VeldridSpirvVersion>1.0.14</VeldridSpirvVersion>
     <NativeLibraryLoaderVersion>1.0.13</NativeLibraryLoaderVersion>
-    <VorticeWindowsVersion>2.1.32</VorticeWindowsVersion>
+    <VorticeWindowsVersion>2.3.0</VorticeWindowsVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Veldrid.Tests/RenderTests.cs
+++ b/src/Veldrid.Tests/RenderTests.cs
@@ -1297,7 +1297,7 @@ namespace Veldrid.Tests
                     float yComp = y * readback.Width;
                     float val = (yComp + xComp) / (readback.Width * readback.Height);
 
-                    Assert.Equal(val, readView[x, y], 2);
+                    Assert.Equal(val, readView[x, y], 2.0f);
                 }
             }
             GD.Unmap(readback);

--- a/src/Veldrid.Tests/Veldrid.Tests.csproj
+++ b/src/Veldrid.Tests/Veldrid.Tests.csproj
@@ -13,11 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="Veldrid.SPIRV" Version="$(VeldridSpirvVersion)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.console" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.3.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.console" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <ProjectReference Include="..\Veldrid.RenderDoc\Veldrid.RenderDoc.csproj" />
     <ProjectReference Include="..\Veldrid.SDL2\Veldrid.SDL2.csproj" />
     <ProjectReference Include="..\Veldrid.StartupUtilities\Veldrid.StartupUtilities.csproj" />

--- a/src/Veldrid.VirtualReality.Sample/Veldrid.VirtualReality.Sample.csproj
+++ b/src/Veldrid.VirtualReality.Sample/Veldrid.VirtualReality.Sample.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Veldrid.VirtualReality/Veldrid.VirtualReality.csproj
+++ b/src/Veldrid.VirtualReality/Veldrid.VirtualReality.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Veldrid/Veldrid.csproj
+++ b/src/Veldrid/Veldrid.csproj
@@ -10,7 +10,7 @@
     <DefineConstants Condition="'$(ExcludeVulkan)' == 'true'">$(DefineConstants);EXCLUDE_VULKAN_BACKEND</DefineConstants>
     <DefineConstants Condition="'$(ExcludeMetal)' == 'true'">$(DefineConstants);EXCLUDE_METAL_BACKEND</DefineConstants>
     <DefineConstants Condition="'$(ExcludeOpenGL)' == 'true'">$(DefineConstants);EXCLUDE_OPENGL_BACKEND</DefineConstants>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
- Update Vortice.Windows to latest 2.3.0 stable version.
- Bump LangVersion to 8.0 as required by Vortice.Windows (PolySharp deps)