### PR TITLE
Fix OpenGL `ClearDepthStencil()` mutating masks

### DIFF
--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -94,28 +94,55 @@ namespace Veldrid.OpenGL
 
         public void ClearDepthStencil(float depth, byte stencil)
         {
-            glClearDepth_Compat(depth);
-            CheckLastError();
+            if (_graphicsPipeline != null)
+            {
+                if (!_graphicsPipeline.DepthStencilState.DepthWriteEnabled)
+                {
+                    glDepthMask(true);
+                    CheckLastError();
+                }
 
-            glStencilMask(~0u);
+                if (_graphicsPipeline.DepthStencilState.StencilWriteMask != 0xFF)
+                {
+                    glStencilMask(0xFF);
+                    CheckLastError();
+                }
+
+                if (_graphicsPipeline.RasterizerState.ScissorTestEnabled)
+                {
+                    glDisable(EnableCap.ScissorTest);
+                    CheckLastError();
+                }
+            }
+
+            glClearDepth_Compat(depth);
             CheckLastError();
 
             glClearStencil(stencil);
             CheckLastError();
 
-            if (_graphicsPipeline != null && _graphicsPipeline.RasterizerState.ScissorTestEnabled)
-            {
-                glDisable(EnableCap.ScissorTest);
-                CheckLastError();
-            }
-
-            glDepthMask(true);
             glClear(ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit);
             CheckLastError();
 
-            if (_graphicsPipeline != null && _graphicsPipeline.RasterizerState.ScissorTestEnabled)
+            if (_graphicsPipeline != null)
             {
-                glEnable(EnableCap.ScissorTest);
+                if (!_graphicsPipeline.DepthStencilState.DepthWriteEnabled)
+                {
+                    glDepthMask(false);
+                    CheckLastError();
+                }
+
+                if (_graphicsPipeline.DepthStencilState.StencilWriteMask != 0xFF)
+                {
+                    glStencilMask(_graphicsPipeline.DepthStencilState.StencilWriteMask);
+                    CheckLastError();
+                }
+
+                if (_graphicsPipeline.RasterizerState.ScissorTestEnabled)
+                {
+                    glEnable(EnableCap.ScissorTest);
+                    CheckLastError();
+                }
             }
         }
 


### PR DESCRIPTION
Specifically, it was leaving the stencil mask to 0xFF and depth writes enabled, and a future call to `SetPipeline()` wouldn't set it back due to this early exit condition:

https://github.com/mellinoe/veldrid/blob/a121087cadf38755f28c397a5b3c42ff1c559a19/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs#L464