### PR TITLE
Fix few issues with Metal on iOS

### DIFF
--- a/src/Veldrid.MetalBindings/NSView.cs
+++ b/src/Veldrid.MetalBindings/NSView.cs
@@ -23,14 +23,9 @@ namespace Veldrid.MetalBindings
             set => objc_msgSend(NativePtr, "setLayer:", value);
         }
 
-        public CGRect frame
-        {
-            get
-            {
-                return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
-                    ? CGRect_objc_msgSend(NativePtr, "frame")
-                    : objc_msgSend_stret<CGRect>(NativePtr, "frame");
-            }
-        }
+        public CGRect frame =>
+            RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? CGRect_objc_msgSend(NativePtr, "frame")
+                : objc_msgSend_stret<CGRect>(NativePtr, "frame");
     }
 }

--- a/src/Veldrid.MetalBindings/UIView.cs
+++ b/src/Veldrid.MetalBindings/UIView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using static Veldrid.MetalBindings.ObjectiveCRuntime;
 
 namespace Veldrid.MetalBindings
@@ -10,6 +11,9 @@ namespace Veldrid.MetalBindings
 
         public CALayer layer => objc_msgSend<CALayer>(NativePtr, "layer");
 
-        public CGRect frame => CGRect_objc_msgSend(NativePtr, "frame");
+        public CGRect frame =>
+            RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? CGRect_objc_msgSend(NativePtr, "frame")
+                : objc_msgSend_stret<CGRect>(NativePtr, "frame");
     }
 }

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -82,16 +82,18 @@ namespace Veldrid.MTL
                 shaderFloat64: false);
             ResourceBindingModel = options.ResourceBindingModel;
 
-            _libSystem = new NativeLibrary("libSystem.dylib");
-            _concreteGlobalBlock = _libSystem.LoadFunction("_NSConcreteGlobalBlock");
             if (MetalFeatures.IsMacOS)
             {
+                _libSystem = new NativeLibrary("libSystem.dylib");
+                _concreteGlobalBlock = _libSystem.LoadFunction("_NSConcreteGlobalBlock");
                 _completionHandler = OnCommandBufferCompleted;
             }
             else
             {
+                _concreteGlobalBlock = IntPtr.Zero;
                 _completionHandler = OnCommandBufferCompleted_Static;
             }
+
             _completionHandlerFuncPtr = Marshal.GetFunctionPointerForDelegate<MTLCommandBufferHandler>(_completionHandler);
             _completionBlockDescriptor = Marshal.AllocHGlobal(Unsafe.SizeOf<BlockDescriptor>());
             BlockDescriptor* descriptorPtr = (BlockDescriptor*)_completionBlockDescriptor;
@@ -439,7 +441,7 @@ namespace Veldrid.MTL
                 s_aotRegisteredBlocks.Remove(_completionBlockLiteral);
             }
 
-            _libSystem.Dispose();
+            _libSystem?.Dispose();
             Marshal.FreeHGlobal(_completionBlockDescriptor);
             Marshal.FreeHGlobal(_completionBlockLiteral);
         }

--- a/src/Veldrid/MTL/MTLSwapchain.cs
+++ b/src/Veldrid/MTL/MTLSwapchain.cs
@@ -74,13 +74,10 @@ namespace Veldrid.MTL
             }
             else if (source is UIViewSwapchainSource uiViewSource)
             {
-                UIScreen mainScreen = UIScreen.mainScreen;
-                CGFloat nativeScale = mainScreen.nativeScale;
-
                 _uiView = new UIView(uiViewSource.UIView);
                 CGSize viewSize = _uiView.frame.size;
-                width = (uint)(viewSize.width * nativeScale);
-                height = (uint)(viewSize.height * nativeScale);
+                width = (uint)viewSize.width;
+                height = (uint)viewSize.height;
 
                 if (!CAMetalLayer.TryCast(_uiView.layer, out _metalLayer))
                 {
@@ -134,21 +131,11 @@ namespace Veldrid.MTL
         public override void Resize(uint width, uint height)
         {
             if (_uiView.NativePtr != IntPtr.Zero)
-            {
-                UIScreen mainScreen = UIScreen.mainScreen;
-                CGFloat nativeScale = mainScreen.nativeScale;
-                width = (uint)(width * nativeScale);
-                height = (uint)(height * nativeScale);
-
                 _metalLayer.frame = _uiView.frame;
-            }
 
-            _framebuffer.Resize(width, height);
             _metalLayer.drawableSize = new CGSize(width, height);
-            if (_uiView.NativePtr != IntPtr.Zero)
-            {
-                _metalLayer.frame = _uiView.frame;
-            }
+            _framebuffer.Resize(width, height);
+
             GetNextDrawable();
         }
 


### PR DESCRIPTION
While trying to run Metal on iOS, I've came across a list of issues all of which are resolved in this PR. I've separated each fix to its own commit.

 - https://github.com/mellinoe/veldrid/commit/7f1d7c885195a7fb3456a2c6f554ce055bcd19e2: Similar to https://github.com/mellinoe/veldrid/commit/fa6481f4d6b578e75b66df293e18042e17be47d4, `CGRect` is too large to use `objc_msgSend` for, therefore `objc_msgSend_stret` is used. That being said, `objc_msgSend_stret` is not available on ARM64 devices, so both are used depending on the process architecture.
 - https://github.com/mellinoe/veldrid/commit/6a7ab9e1ff3573d79c3b2afed37036d57fcb07e1: Loading native library on iOS is not supported, and not passing a metaclass pointer at all doesn't look to break anything as far as I've checked, therefore I suppose it's fine to keep it null?
 - https://github.com/mellinoe/veldrid/commit/c136871687fde32dca460b4d7e77d7fa38b94c6a: Applying a native scale to `CAMetalLayer.drawableSize` causes the application to actually be descaled by the same factor instead. Removing the scale factor fixes the issue, and macOS doesn't do it at all in the first place. 