### PR TITLE
Add support for feature level 10_0

### DIFF
--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -97,6 +97,7 @@ namespace Veldrid.D3D11
                         {
                             Vortice.Direct3D.FeatureLevel.Level_11_1,
                             Vortice.Direct3D.FeatureLevel.Level_11_0,
+                            Vortice.Direct3D.FeatureLevel.Level_10_0,
                         },
                         out _device).CheckError();
                 }
@@ -109,6 +110,7 @@ namespace Veldrid.D3D11
                         {
                             Vortice.Direct3D.FeatureLevel.Level_11_1,
                             Vortice.Direct3D.FeatureLevel.Level_11_0,
+                            Vortice.Direct3D.FeatureLevel.Level_10_0,
                         },
                         out _device).CheckError();
                 }

--- a/src/Veldrid/D3D11/D3D11Shader.cs
+++ b/src/Veldrid/D3D11/D3D11Shader.cs
@@ -60,22 +60,22 @@ namespace Veldrid.D3D11
             switch (description.Stage)
             {
                 case ShaderStages.Vertex:
-                    profile = "vs_5_0";
+                    profile = "vs_4_0";
                     break;
                 case ShaderStages.Geometry:
-                    profile = "gs_5_0";
+                    profile = "gs_4_0";
                     break;
                 case ShaderStages.TessellationControl:
-                    profile = "hs_5_0";
+                    profile = "hs_4_0";
                     break;
                 case ShaderStages.TessellationEvaluation:
-                    profile = "ds_5_0";
+                    profile = "ds_4_0";
                     break;
                 case ShaderStages.Fragment:
-                    profile = "ps_5_0";
+                    profile = "ps_4_0";
                     break;
                 case ShaderStages.Compute:
-                    profile = "cs_5_0";
+                    profile = "cs_4_0";
                     break;
                 default:
                     throw Illegal.Value<ShaderStages>();


### PR DESCRIPTION
# Do not merge

I'm making this branch both as a tracking branch for our own fork where we use feature level 10_0 to target older devices like [9800gt](https://www.techpowerup.com/gpu-specs/geforce-9800-gt.c635), and as a place to discuss how this could be mainlined if at all.

For example, should I track the selected feature level to retarget the shader version?