### PR TITLE
Use flip model for D3D11 swapchains

### DIFF
--- a/src/Veldrid/D3D11/D3D11Swapchain.cs
+++ b/src/Veldrid/D3D11/D3D11Swapchain.cs
@@ -88,7 +88,7 @@ namespace Veldrid.D3D11
                         (int)description.Width, (int)description.Height, _colorFormat),
                     OutputWindow = win32Source.Hwnd,
                     SampleDescription = new SampleDescription(1, 0),
-                    SwapEffect = SwapEffect.Discard,
+                    SwapEffect = SwapEffect.FlipDiscard,
                     BufferUsage = Usage.RenderTargetOutput
                 };
 


### PR DESCRIPTION
As documented [here](https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/dxgi-flip-model), [here](https://www.youtube.com/watch?v=E3wTajGZOsA) and [here](https://github.com/MicrosoftDocs/win32/blob/docs/desktop-src/direct3ddxgi/for-best-performance--use-dxgi-flip-model.md), the flip model has performance advantages compared to the blt model.