### PR TITLE
Allow D3D devices to tear if requested

### DIFF
--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -235,7 +235,17 @@ namespace Veldrid.D3D11
             lock (_immediateContextLock)
             {
                 D3D11Swapchain d3d11SC = Util.AssertSubtype<Swapchain, D3D11Swapchain>(swapchain);
-                d3d11SC.DxgiSwapChain.Present(d3d11SC.SyncInterval, PresentFlags.None);
+
+                int syncInterval = d3d11SC.SyncInterval;
+                PresentFlags flags = PresentFlags.None;
+
+                if (_mainSwapchain.TearingAllowed && AllowTearing)
+                {
+                    syncInterval = 0;
+                    flags |= PresentFlags.AllowTearing;
+                }
+
+                d3d11SC.DxgiSwapChain.Present(syncInterval, flags);
             }
         }
 

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -93,6 +93,11 @@ namespace Veldrid
         }
 
         /// <summary>
+        /// Gets or sets whether the graphics device should allow frames to be displayed as fast as possible even if tearing occurs.
+        /// </summary>
+        public virtual bool AllowTearing { get; set; }
+
+        /// <summary>
         /// The required alignment, in bytes, for uniform buffer offsets. <see cref="DeviceBufferRange.Offset"/> must be a
         /// multiple of this value. When binding a <see cref="ResourceSet"/> to a <see cref="CommandList"/> with an overload
         /// accepting dynamic offsets, each offset must be a multiple of this value.


### PR DESCRIPTION
Perhaps to be seen as required for https://github.com/mellinoe/veldrid/pull/484 since Microsoft [recommend this while using the flip model](https://github.com/MicrosoftDocs/win32/blob/docs/desktop-src/direct3ddxgi/for-best-performance--use-dxgi-flip-model.md).

This enables `DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING` on the swapchain and allows presenting this way via `GraphicsDevice.AllowTearing`. Doing so forces the sync interval to 0 as required by the documentation [here](https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/dxgi-present).