### PR TITLE
Fix Vulkan _scImages array not resizing when scImageCount changes

### DIFF
--- a/src/Veldrid/Vk/VkSwapchainFramebuffer.cs
+++ b/src/Veldrid/Vk/VkSwapchainFramebuffer.cs
@@ -16,7 +16,7 @@ namespace Veldrid.Vk
         private uint _currentImageIndex;
 
         private VkFramebuffer[] _scFramebuffers;
-        private VkImage[] _scImages;
+        private VkImage[] _scImages = {};
         private VkFormat _scImageFormat;
         private VkExtent2D _scExtent;
         private FramebufferAttachment[][] _scColorTextures;
@@ -90,7 +90,7 @@ namespace Veldrid.Vk
             uint scImageCount = 0;
             VkResult result = vkGetSwapchainImagesKHR(_gd.Device, deviceSwapchain, ref scImageCount, null);
             CheckResult(result);
-            if (_scImages == null)
+            if (_scImages.Length < scImageCount)
             {
                 _scImages = new VkImage[(int)scImageCount];
             }


### PR DESCRIPTION
After initializing the array for _scImages, SetNewSwapchain only checks that _scImages == null. However, after _scImages is set to the length of scImageCount, scImageCount can increase in value, causing an index outside of the bounds of the array error. This change initializes _scImages as an empty array, and the check for null is replaced by a check for if _scImages.Length < scImageCount.