### PR TITLE
Update Vortice.D3D11

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <VeldridSpirvVersion>1.0.14</VeldridSpirvVersion>
     <NativeLibraryLoaderVersion>1.0.13</NativeLibraryLoaderVersion>
-    <VorticeWindowsVersion>2.3.0</VorticeWindowsVersion>
+    <VorticeWindowsVersion>2.4.2</VorticeWindowsVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Veldrid/D3D11/D3D11ResourceCache.cs
+++ b/src/Veldrid/D3D11/D3D11ResourceCache.cs
@@ -71,7 +71,7 @@ namespace Veldrid.D3D11
             for (int i = 0; i < attachmentStates.Length; i++)
             {
                 BlendAttachmentDescription state = attachmentStates[i];
-                d3dBlendStateDesc.RenderTarget[i].IsBlendEnabled = state.BlendEnabled;
+                d3dBlendStateDesc.RenderTarget[i].BlendEnable = state.BlendEnabled;
                 d3dBlendStateDesc.RenderTarget[i].RenderTargetWriteMask = D3D11Formats.VdToD3D11ColorWriteEnable(state.ColorWriteMask.GetOrDefault());
                 d3dBlendStateDesc.RenderTarget[i].SourceBlend = D3D11Formats.VdToD3D11Blend(state.SourceColorFactor);
                 d3dBlendStateDesc.RenderTarget[i].DestinationBlend = D3D11Formats.VdToD3D11Blend(state.DestinationColorFactor);

--- a/src/Veldrid/D3D11/D3D11Sampler.cs
+++ b/src/Veldrid/D3D11/D3D11Sampler.cs
@@ -22,7 +22,7 @@ namespace Veldrid.D3D11
                 MinLOD = description.MinimumLod,
                 MaxLOD = description.MaximumLod,
                 MaxAnisotropy = (int)description.MaximumAnisotropy,
-                ComparisonFunction = comparision,
+                ComparisonFunc = comparision,
                 MipLODBias = description.LodBias,
                 BorderColor = ToRawColor4(description.BorderColor)
             };


### PR DESCRIPTION
Mostly interested in pulling in https://github.com/amerkoleci/Vortice.Windows/commit/1845cc46a65698cc6b3c620253e760bcda2b2de4, which fixes MinLOD/MaxLOD not being passed properly (always 0 - 0).