### PR TITLE
Fix Metal discarding depth content when ending a render pass

### DIFF
--- a/src/Veldrid/MTL/MTLSwapchainFramebuffer.cs
+++ b/src/Veldrid/MTL/MTLSwapchainFramebuffer.cs
@@ -93,6 +93,15 @@ namespace Veldrid.MTL
                 depthAttachment.texture = _depthTexture.DeviceTexture;
                 depthAttachment.loadAction = MTLLoadAction.Load;
                 depthAttachment.storeAction = MTLStoreAction.Store;
+
+                if (FormatHelpers.IsStencilFormat(_depthTarget.Value.Target.Format))
+                {
+                    MTLRenderPassStencilAttachmentDescriptor stencilDescriptor = ret.stencilAttachment;
+                    stencilDescriptor.loadAction = MTLLoadAction.Load;
+                    stencilDescriptor.storeAction = MTLStoreAction.Store;
+                    stencilDescriptor.texture = _depthTexture.DeviceTexture;
+                    stencilDescriptor.slice = (UIntPtr)_depthTarget.Value.ArrayLayer;
+                }
             }
 
             return ret;

--- a/src/Veldrid/MTL/MTLSwapchainFramebuffer.cs
+++ b/src/Veldrid/MTL/MTLSwapchainFramebuffer.cs
@@ -92,6 +92,7 @@ namespace Veldrid.MTL
                 var depthAttachment = ret.depthAttachment;
                 depthAttachment.texture = _depthTexture.DeviceTexture;
                 depthAttachment.loadAction = MTLLoadAction.Load;
+                depthAttachment.storeAction = MTLStoreAction.Store;
             }
 
             return ret;


### PR DESCRIPTION
This caused our game to fail rendering on the A12 GPU family, and took me a very long time to figure out as Xcode's Metal debugger feature did not show the depth content to actually have garbage content.

I've also included handling for the stencil content as well similar to `MTLFramebuffer`, since I don't see why not.