### PR TITLE
Added lock to prevent race condition

### DIFF
--- a/src/Veldrid/Vk/VkCommandList.cs
+++ b/src/Veldrid/Vk/VkCommandList.cs
@@ -461,7 +461,10 @@ namespace Veldrid.Vk
             }
 
             vkEndCommandBuffer(_cb);
-            _submittedCommandBuffers.Add(_cb);
+            lock (_commandBufferListLock)
+            {
+                _submittedCommandBuffers.Add(_cb);
+            }
         }
 
         protected override void SetFramebufferCore(Framebuffer fb)


### PR DESCRIPTION
`VkCommandList.CommandBufferCompleted(VkCommandBuffer completedCB)` competes with `VkCommandList.End()` resulting in a race condition:

https://github.com/mellinoe/veldrid/blob/367f3ec52f92ffe65681cafd16cb65d9f89e0af0/src/Veldrid/Vk/VkCommandList.cs#L114
https://github.com/mellinoe/veldrid/blob/367f3ec52f92ffe65681cafd16cb65d9f89e0af0/src/Veldrid/Vk/VkCommandList.cs#L464