### PR TITLE
Cache Metal pipeline/depth states for re-use in future pipeline compilations

### DIFF
--- a/src/Veldrid/MTL/MTLPipeline.cs
+++ b/src/Veldrid/MTL/MTLPipeline.cs
@@ -333,11 +333,19 @@ namespace Veldrid.MTL
             {
                 if (RenderPipelineState.NativePtr != IntPtr.Zero)
                 {
+                    render_pipeline_states.Remove(render_pipeline_states.Single(kvp => kvp.Value.NativePtr == RenderPipelineState.NativePtr).Key);
                     ObjectiveCRuntime.release(RenderPipelineState.NativePtr);
                 }
-                else
+
+                if (DepthStencilState.NativePtr != IntPtr.Zero)
                 {
-                    Debug.Assert(ComputePipelineState.NativePtr != IntPtr.Zero);
+                    depth_stencil_states.Remove(depth_stencil_states.Single(kvp => kvp.Value.NativePtr == DepthStencilState.NativePtr).Key);
+                    ObjectiveCRuntime.release(DepthStencilState.NativePtr);
+                }
+
+                if (ComputePipelineState.NativePtr != IntPtr.Zero)
+                {
+                    compute_pipeline_states.Remove(compute_pipeline_states.Single(kvp => kvp.Value.NativePtr == ComputePipelineState.NativePtr).Key);
                     ObjectiveCRuntime.release(ComputePipelineState.NativePtr);
                 }
 


### PR DESCRIPTION
A `GraphicsPipeline` in Veldrid translates to four states in Metal (`MTLRenderPipelineState`, `MTLComputePipelineState`, `MTLDepthStencilState`, and `ThreadsPerThreadgroup`). Multiple pipelines may be compiled to change certain states while keeping others as-is, this aims to cache all four states to re-use them for all pipelines where feasible and ultimately to reduce redundant bind calls which will come in another PR.

I've let disposal remove the caches mainly because the underlying device resources in the pipeline states are likely to be disposed themselves, so it's pointless to keep the cache existing.