### PR TITLE
Avoid encoding redundant Metal render/compute commands to reduce CPU time

### DIFF
--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -24,8 +24,8 @@ namespace Veldrid.MTL
         private MTLIndexType _indexType;
         private MTLPipeline _lastGraphicsPipeline;
         private new MTLPipeline _graphicsPipeline;
+        private MTLPipeline _lastComputePipeline;
         private new MTLPipeline _computePipeline;
-        private bool _computePipelineChanged;
         private MTLViewport[] _viewports = Array.Empty<MTLViewport>();
         private bool _viewportsChanged;
         private MTLScissorRect[] _scissorRects = Array.Empty<MTLScissorRect>();
@@ -263,10 +263,11 @@ namespace Veldrid.MTL
         private void PreComputeCommand()
         {
             EnsureComputeEncoder();
-            if (_computePipelineChanged)
-            {
+
+            if (_computePipeline.ComputePipelineState.NativePtr != _lastComputePipeline?.ComputePipelineState.NativePtr)
                 _cce.setComputePipelineState(_computePipeline.ComputePipelineState);
-            }
+
+            _lastComputePipeline = _computePipeline;
 
             for (uint i = 0; i < _computeResourceSetCount; i++)
             {
@@ -299,7 +300,6 @@ namespace Veldrid.MTL
                 Util.EnsureArrayMinimumSize(ref _computeResourceSets, _computeResourceSetCount);
                 Util.EnsureArrayMinimumSize(ref _computeResourceSetsActive, _computeResourceSetCount);
                 Util.ClearArray(_computeResourceSetsActive);
-                _computePipelineChanged = true;
             }
             else
             {
@@ -1081,7 +1081,7 @@ namespace Veldrid.MTL
                 _cce.endEncoding();
                 ObjectiveCRuntime.release(_cce.NativePtr);
                 _cce = default(MTLComputeCommandEncoder);
-                _computePipelineChanged = true;
+                _lastComputePipeline = null;
                 Util.ClearArray(_computeResourceSetsActive);
             }
 

--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -222,6 +222,7 @@ namespace Veldrid.MTL
                             _vertexBuffers[i].DeviceBuffer,
                             (UIntPtr)_vbOffsets[i],
                             index);
+                        _vertexBuffersActive[i] = true;
                     }
                 }
                 return true;
@@ -1066,6 +1067,7 @@ namespace Veldrid.MTL
             _boundFragmentTextures.Clear();
             _boundFragmentSamplers.Clear();
             Util.ClearArray(_graphicsResourceSetsActive);
+            Util.ClearArray(_vertexBuffersActive);
 
             _viewportsChanged = true;
             _scissorRectsChanged = true;

--- a/src/Veldrid/MTL/MTLCommandList.cs
+++ b/src/Veldrid/MTL/MTLCommandList.cs
@@ -293,7 +293,7 @@ namespace Veldrid.MTL
 
         private protected override void SetPipelineCore(Pipeline pipeline)
         {
-            if (pipeline.IsComputePipeline)
+            if (pipeline.IsComputePipeline && _computePipeline != pipeline)
             {
                 _computePipeline = Util.AssertSubtype<Pipeline, MTLPipeline>(pipeline);
                 _computeResourceSetCount = (uint)_computePipeline.ResourceLayouts.Length;
@@ -301,7 +301,7 @@ namespace Veldrid.MTL
                 Util.EnsureArrayMinimumSize(ref _computeResourceSetsActive, _computeResourceSetCount);
                 Util.ClearArray(_computeResourceSetsActive);
             }
-            else
+            else if (!pipeline.IsComputePipeline && _graphicsPipeline != pipeline)
             {
                 _graphicsPipeline = Util.AssertSubtype<Pipeline, MTLPipeline>(pipeline);
                 _graphicsResourceSetCount = (uint)_graphicsPipeline.ResourceLayouts.Length;


### PR DESCRIPTION
Xcode has been yelling about this for a while now but I haven't realised how bad the overhead is until I've profiled it myself. This PR reduces down all encoding commands as much as possible to save CPU time.

| Before | After |
|--------|-------|
| <img src="https://user-images.githubusercontent.com/22781491/231953285-c1a64cd3-cfa9-4f06-b38e-0ee0a514ffe0.png" /> | <img src="https://user-images.githubusercontent.com/22781491/231953705-91f1e614-aebb-4172-8182-e388d8dcc140.png" /> |

(late texture creation warning is irrelevant)