### PR TITLE
Use private storage mode for non-staging/non-dynamic `MTLBuffer`s

### DIFF
--- a/src/Veldrid/MTL/MTLBuffer.cs
+++ b/src/Veldrid/MTL/MTLBuffer.cs
@@ -35,9 +35,13 @@ namespace Veldrid.MTL
             uint roundFactor = (4 - (SizeInBytes % 4)) % 4;
             ActualCapacity = SizeInBytes + roundFactor;
             Usage = bd.Usage;
+
+            var sharedMemory = Usage == BufferUsage.Staging || (Usage & BufferUsage.Dynamic) == BufferUsage.Dynamic;
+            var bufferOptions = sharedMemory ? MTLResourceOptions.StorageModeShared : MTLResourceOptions.StorageModePrivate;
+
             DeviceBuffer = gd.Device.newBufferWithLengthOptions(
                 (UIntPtr)ActualCapacity,
-                0);
+                bufferOptions);
         }
 
         public override void Dispose()


### PR DESCRIPTION
["Private" storage mode](https://developer.apple.com/documentation/metal/mtlresourceoptions/1515324-storagemodeprivate) is better suited for buffers that are never accessed by the CPU, allowing Metal to apply optimisations on them. This would benefit any non-staging/non-dynamic buffers populated using blit commands (such as vertex buffers, index buffers, uniform buffers, etc.)