### PR TITLE
Cache `MTLBuffer` contents pointer to avoid API call overhead

### DIFF
--- a/src/Veldrid/MTL/MTLBuffer.cs
+++ b/src/Veldrid/MTL/MTLBuffer.cs
@@ -29,6 +29,8 @@ namespace Veldrid.MTL
 
         public MetalBindings.MTLBuffer DeviceBuffer { get; private set; }
 
+        public unsafe void* Pointer { get; private set; }
+
         public MTLBuffer(ref BufferDescription bd, MTLGraphicsDevice gd)
         {
             SizeInBytes = bd.SizeInBytes;
@@ -38,6 +40,11 @@ namespace Veldrid.MTL
             DeviceBuffer = gd.Device.newBufferWithLengthOptions(
                 (UIntPtr)ActualCapacity,
                 0);
+
+            unsafe
+            {
+                Pointer = DeviceBuffer.contents();
+            }
         }
 
         public override void Dispose()

--- a/src/Veldrid/MTL/MTLGraphicsDevice.cs
+++ b/src/Veldrid/MTL/MTLGraphicsDevice.cs
@@ -312,7 +312,7 @@ namespace Veldrid.MTL
         private protected override void UpdateBufferCore(DeviceBuffer buffer, uint bufferOffsetInBytes, IntPtr source, uint sizeInBytes)
         {
             var mtlBuffer = Util.AssertSubtype<DeviceBuffer, MTLBuffer>(buffer);
-            void* destPtr = mtlBuffer.DeviceBuffer.contents();
+            void* destPtr = mtlBuffer.Pointer;
             byte* destOffsetPtr = (byte*)destPtr + bufferOffsetInBytes;
             Unsafe.CopyBlock(destOffsetPtr, source.ToPointer(), sizeInBytes);
         }
@@ -358,7 +358,7 @@ namespace Veldrid.MTL
                     source.ToPointer(),
                     0, 0, 0,
                     srcRowPitch, srcDepthPitch,
-                    (byte*)mtlTex.StagingBuffer.contents() + dstOffset,
+                    (byte*)mtlTex.StagingBufferPointer + dstOffset,
                     x, y, z,
                     dstRowPitch, dstDepthPitch,
                     width, height, depth,
@@ -398,11 +398,10 @@ namespace Veldrid.MTL
 
         private MappedResource MapBuffer(MTLBuffer buffer, MapMode mode)
         {
-            void* data = buffer.DeviceBuffer.contents();
             return new MappedResource(
                 buffer,
                 mode,
-                (IntPtr)data,
+                (IntPtr)buffer.Pointer,
                 buffer.SizeInBytes,
                 0,
                 buffer.SizeInBytes,
@@ -412,7 +411,7 @@ namespace Veldrid.MTL
         private MappedResource MapTexture(MTLTexture texture, MapMode mode, uint subresource)
         {
             Debug.Assert(!texture.StagingBuffer.IsNull);
-            void* data = texture.StagingBuffer.contents();
+            void* data = texture.StagingBufferPointer;
             Util.GetMipLevelAndArrayLayer(texture, subresource, out uint mipLevel, out uint arrayLayer);
             Util.GetMipDimensions(texture, mipLevel, out uint width, out uint height, out uint depth);
             uint subresourceSize = texture.GetSubresourceSize(mipLevel, arrayLayer);

--- a/src/Veldrid/MTL/MTLTexture.cs
+++ b/src/Veldrid/MTL/MTLTexture.cs
@@ -16,6 +16,8 @@ namespace Veldrid.MTL
         /// </summary>
         public MetalBindings.MTLBuffer StagingBuffer { get; }
 
+        public unsafe void* StagingBufferPointer { get; private set; }
+
         public override PixelFormat Format { get; }
 
         public override uint Width { get; }
@@ -93,6 +95,11 @@ namespace Veldrid.MTL
                 StagingBuffer = _gd.Device.newBufferWithLengthOptions(
                     (UIntPtr)totalStorageSize,
                     MTLResourceOptions.StorageModeShared);
+
+                unsafe
+                {
+                    StagingBufferPointer = StagingBuffer.contents();
+                }
             }
         }
 


### PR DESCRIPTION
This becomes very apparent when updating buffers without using blit commands. Where 99% of the overhead comes from retrieving the pointer using `MTLBuffer.contents()`.

Before:

![CleanShot 2023-04-15 at 12 50 52](https://user-images.githubusercontent.com/22781491/232206792-d2a225b2-97eb-4ca6-a6e3-7af26fd708bc.png)

(notice `MTLBuffer.contents()` being the number one hotspot in a 15s record of a game)

After:

![CleanShot 2023-04-15 at 12 51 02](https://user-images.githubusercontent.com/22781491/232206795-22ba7fa8-10ec-405a-9d7e-06651a63a4a2.png)
