### PR TITLE
support stencil buffer on GLES + FIX GL/GLES eglGetDisplay paramater bug

### DIFF
--- a/src/Veldrid/OpenGL/EGL/EGLNative.cs
+++ b/src/Veldrid/OpenGL/EGL/EGLNative.cs
@@ -14,6 +14,7 @@ namespace Veldrid.OpenGL.EGL
         public const int EGL_BLUE_SIZE = 0x3022;
         public const int EGL_ALPHA_SIZE = 0x3021;
         public const int EGL_DEPTH_SIZE = 0x3025;
+        public const int EGL_STENCIL_SIZE = 0x3026;
         public const int EGL_SURFACE_TYPE = 0x3033;
         public const int EGL_WINDOW_BIT = 0x0004;
         public const int EGL_OPENGL_ES_BIT = 0x0001;
@@ -39,7 +40,7 @@ namespace Veldrid.OpenGL.EGL
         [DllImport(LibName)]
         public static extern IntPtr eglGetCurrentDisplay();
         [DllImport(LibName)]
-        public static extern IntPtr eglGetDisplay(int native_display);
+        public static extern IntPtr eglGetDisplay(IntPtr native_display);
         [DllImport(LibName)]
         public static extern IntPtr eglGetCurrentSurface(int readdraw);
         [DllImport(LibName)]

--- a/src/Veldrid/OpenGL/OpenGLExtensions.cs
+++ b/src/Veldrid/OpenGL/OpenGLExtensions.cs
@@ -64,6 +64,13 @@ namespace Veldrid.OpenGL
             ARB_uniform_buffer_object = IsExtensionSupported("GL_ARB_uniform_buffer_object");
 
             AnisotropicFilter = IsExtensionSupported("GL_EXT_texture_filter_anisotropic") || IsExtensionSupported("GL_ARB_texture_filter_anisotropic");
+
+            // D24_UNorm_S8_UInt (GL_DEPTH24_STENCIL8) is core in GL 3.0+ and GLES 3.0+.
+            // On desktop GL 2.x, GL_ARB_framebuffer_object provides it.
+            // On GLES 2.x, it requires the GL_OES_packed_depth_stencil extension.
+            OesPackedDepthStencil = GLVersion(3, 0) || GLESVersion(3, 0)
+                                    || IsExtensionSupported("GL_ARB_framebuffer_object")
+                                    || IsExtensionSupported("GL_OES_packed_depth_stencil");
         }
 
         public readonly bool ARB_DirectStateAccess;
@@ -92,6 +99,7 @@ namespace Veldrid.OpenGL
         public readonly bool MultiDrawIndirect;
         public readonly bool StorageBuffers;
         public readonly bool AnisotropicFilter;
+        public readonly bool OesPackedDepthStencil;
 
         /// <summary>
         /// Returns a value indicating whether the given extension is supported.

--- a/src/Veldrid/OpenGL/OpenGLFormats.cs
+++ b/src/Veldrid/OpenGL/OpenGLFormats.cs
@@ -699,6 +699,11 @@ namespace Veldrid.OpenGL
                 case PixelFormat.R10_G10_B10_A2_UNorm:
                     return backend == GraphicsBackend.OpenGL;
 
+                case PixelFormat.D24_UNorm_S8_UInt:
+                    return extensions.GLVersion(3, 0) || extensions.GLESVersion(3, 0)
+                           || extensions.IsExtensionSupported("GL_OES_packed_depth_stencil")
+                           || extensions.IsExtensionSupported("GL_ARB_framebuffer_object");
+
                 default:
                     return true;
             }

--- a/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
+++ b/src/Veldrid/OpenGL/OpenGLGraphicsDevice.cs
@@ -615,7 +615,7 @@ namespace Veldrid.OpenGL
             IntPtr aNativeWindow,
             SwapchainDescription swapchainDescription)
         {
-            IntPtr display = eglGetDisplay(0);
+            IntPtr display = eglGetDisplay(IntPtr.Zero);
             if (display == IntPtr.Zero)
             {
                 throw new VeldridException($"Failed to get the default Android EGLDisplay: {eglGetError()}");
@@ -636,6 +636,10 @@ namespace Veldrid.OpenGL
                 EGL_DEPTH_SIZE,
                 swapchainDescription.DepthFormat != null
                     ? GetDepthBits(swapchainDescription.DepthFormat.Value)
+                    : 0,
+                EGL_STENCIL_SIZE,
+                swapchainDescription.DepthFormat != null
+                    ? GetStencilBits(swapchainDescription.DepthFormat.Value)
                     : 0,
                 EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
                 EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
@@ -746,6 +750,25 @@ namespace Veldrid.OpenGL
                     return 16;
                 case PixelFormat.R32_Float:
                     return 32;
+                case PixelFormat.D24_UNorm_S8_UInt:
+                    return 24;
+                case PixelFormat.D32_Float_S8_UInt:
+                    return 32;
+                default:
+                    throw new VeldridException($"Unsupported depth format: {value}");
+            }
+        }
+
+        private static int GetStencilBits(PixelFormat value)
+        {
+            switch (value)
+            {
+                case PixelFormat.D24_UNorm_S8_UInt:
+                case PixelFormat.D32_Float_S8_UInt:
+                    return 8;
+                case PixelFormat.R16_UNorm:
+                case PixelFormat.R32_Float:
+                    return 0;
                 default:
                     throw new VeldridException($"Unsupported depth format: {value}");
             }

--- a/src/Veldrid/OpenGL/OpenGLTexture.cs
+++ b/src/Veldrid/OpenGL/OpenGLTexture.cs
@@ -18,7 +18,7 @@ namespace Veldrid.OpenGL
 
         private string _name;
         private bool _nameChanged;
-        
+
         public override string Name { get => _name; set { _name = value; _nameChanged = true; } }
 
         public uint Texture => _texture;
@@ -30,7 +30,17 @@ namespace Veldrid.OpenGL
             Width = description.Width;
             Height = description.Height;
             Depth = description.Depth;
-            Format = description.Format;
+
+            if (description.Format == PixelFormat.D24_UNorm_S8_UInt && !gd.Extensions.OesPackedDepthStencil)
+            {
+                Console.WriteLine(
+                    "[Veldrid] GL_OES_packed_depth_stencil not available — downgrading D24_UNorm_S8_UInt to D32_Float_S8_UInt");
+                Format = PixelFormat.D32_Float_S8_UInt;
+            }
+            else
+            {
+                Format = description.Format;
+            }
             MipLevels = description.MipLevels;
             ArrayLayers = description.ArrayLayers;
             Usage = description.Usage;
@@ -93,7 +103,17 @@ namespace Veldrid.OpenGL
             Width = description.Width;
             Height = description.Height;
             Depth = description.Depth;
-            Format = description.Format;
+
+            if (description.Format == PixelFormat.D24_UNorm_S8_UInt && !gd.Extensions.OesPackedDepthStencil)
+            {
+                Console.WriteLine(
+                    "[Veldrid] GL_OES_packed_depth_stencil not available — downgrading D24_UNorm_S8_UInt to D32_Float_S8_UInt");
+                Format = PixelFormat.D32_Float_S8_UInt;
+            }
+            else
+            {
+                Format = description.Format;
+            }
             MipLevels = description.MipLevels;
             ArrayLayers = description.ArrayLayers;
             Usage = description.Usage;


### PR DESCRIPTION
- Add EGL_STENCIL_SIZE constant for stencil buffer configuration
- Fix eglGetDisplay parameter type from int to IntPtr
- Add OesPackedDepthStencil extension detection for GL_OES_packed_depth_stencil
- Add D24_UNorm_S8_UInt format support check in OpenGLFormats
- Add GetStencilBits helper method for EGL stencil configuration
- Update GetDepthBits to support D24/D32 stencil formats
- Add format downgrade from D24_UNorm_S8_UInt to D32_Float_S8_UInt when packed depth/stencil not available